### PR TITLE
Added support for custom uid:gid for NGINX Plus unprivileged images

### DIFF
--- a/nginx/docker-image-builder/README.md
+++ b/nginx/docker-image-builder/README.md
@@ -51,6 +51,7 @@ NGINX Docker Image builder
  -w                     - Add NGINX App Protect WAF (requires NGINX Plus)
  -O                     - Use NGINX Open Source instead of NGINX Plus
  -u                     - Build unprivileged image (only for NGINX Plus)
+ -i [uid:gid]           - Set NGINX UID and GID (only for unprivileged images)
  -a [2|3]               - Add NGINX Agent v2 or v3
 
  === Examples:
@@ -63,6 +64,9 @@ NGINX Docker Image builder
 
  NGINX Plus, NGINX App Protect WAF and NGINX Agent unprivileged image:
  ./scripts/build.sh -C nginx-repo.crt -K nginx-repo.key -t registry.ff.lan:31005/nginx-docker:plus-nap-agent-nonroot -w -u -a 2
+
+ NGINX Plus, NGINX App Protect WAF and NGINX Agent unprivileged image, custom UID and GID:
+ ./scripts/build.sh -C nginx-repo.crt -K nginx-repo.key -t registry.ff.lan:31005/nginx-docker:plus-nap-agent-nonroot -w -u -i 1234:1234 -a 2
 
  NGINX Opensource and NGINX Agent image:
  ./scripts/build.sh -O -t registry.ff.lan:31005/nginx-docker:oss-root -a 2

--- a/nginx/docker-image-builder/scripts/build.sh
+++ b/nginx/docker-image-builder/scripts/build.sh
@@ -14,6 +14,7 @@ $0 [options]\n\n
 -w\t\t\t- Add NGINX App Protect WAF (requires NGINX Plus)\n
 -O\t\t\t- Use NGINX Open Source instead of NGINX Plus\n
 -u\t\t\t- Build unprivileged image (only for NGINX Plus)\n
+-i [uid:gid]\t\t- Set NGINX UID and GID (only for unprivileged images)\n
 -a [2|3]\t\t- Add NGINX Agent v2 or v3\n\n
 === Examples:\n\n
 NGINX Plus and NGINX Agent image:\n
@@ -25,107 +26,127 @@ NGINX Plus, NGINX App Protect WAF and NGINX Agent image:\n
 NGINX Plus, NGINX App Protect WAF and NGINX Agent unprivileged image:\n
   $0 -C nginx-repo.crt -K nginx-repo.key -t registry.ff.lan:31005/nginx-docker:plus-nap-agent-nonroot -w -u -a 2\n\n
 
+NGINX Plus, NGINX App Protect WAF and NGINX Agent unprivileged image, custom UID and GID:\n
+  $0 -C nginx-repo.crt -K nginx-repo.key -t registry.ff.lan:31005/nginx-docker:plus-nap-agent-nonroot -w -u -i 1001770001:1001770001 -a 2\n\n
+
 NGINX Opensource and NGINX Agent image:\n
   $0 -O -t registry.ff.lan:31005/nginx-docker:oss-root -a 2\n"
 
-while getopts 'ht:C:K:a:wOu' OPTION
+NGINX_UID=101
+NGINX_GID=101
+
+while getopts 'ht:C:K:a:wOui:' OPTION
 do
-	case "$OPTION" in
-		h)
-			echo -e $BANNER
-			exit
-		;;
-		t)
-			IMAGENAME=$OPTARG
-		;;
-		C)
-			NGINX_CERT=$OPTARG
-		;;
-		K)
-			NGINX_KEY=$OPTARG
-		;;
-		a)
-			NGINX_AGENT=true
-			NGINX_AGENT_VERSION=$OPTARG
-		;;
-		w)
-			NAP_WAF=true
-		;;
-		O)
-			NGINX_OSS=true
-		;;
-		u)
-			UNPRIVILEGED=true
-		;;
-	esac
+  case "$OPTION" in
+    h)
+      echo -e $BANNER
+      exit
+    ;;
+    t)
+      IMAGENAME=$OPTARG
+    ;;
+    C)
+      NGINX_CERT=$OPTARG
+    ;;
+    K)
+      NGINX_KEY=$OPTARG
+    ;;
+    a)
+      NGINX_AGENT=true
+      NGINX_AGENT_VERSION=$OPTARG
+    ;;
+    w)
+      NAP_WAF=true
+    ;;
+    O)
+      NGINX_OSS=true
+    ;;
+    u)
+      UNPRIVILEGED=true
+    ;;
+    i)
+      NGINX_UID=`echo $OPTARG | awk -F: '{print $1}'`
+      NGINX_GID=`echo $OPTARG | awk -F: '{print $2}'`
+    ;;
+  esac
 done
 
 if [ -z "$1" ]
 then
-	echo -e $BANNER
-	exit
+  echo -e $BANNER
+  exit
 fi
 
 if [ -z "${IMAGENAME}" ]
 then
-        echo "Docker image name is required"
-        exit
+  echo "Docker image name is required"
+  exit
 fi
 
 if [ -z "${NGINX_AGENT_VERSION}" ]
 then
-        echo "NGINX Agent version is required"
-        exit
+  echo "NGINX Agent version is required"
+  exit
 fi
 
 if ([ -z "${NGINX_OSS}" ] && ([ -z "${NGINX_CERT}" ] || [ -z "${NGINX_KEY}" ]) )
 then
-        echo "NGINX certificate and key are required for automated installation"
-        exit
+  echo "NGINX certificate and key are required for NGINX Plus"
+  exit
+fi
+
+if ([ -z "${NGINX_UID}" ] || -z "${NGINX_GID}" ])
+then
+  echo "Invalid UID and/or GID"
+  exit
+fi
+
+if [ "${NGINX_AGENT}" ]
+then
+  if [ "${NGINX_AGENT_VERSION}" -eq "2" ] || [ "${NGINX_AGENT_VERSION}" -eq "3" ]
+  then
+    echo "=> Building with NGINX Agent v${NGINX_AGENT_VERSION}"
+  else
+    echo "NGINX Agent version must be either '2' or '3'"
+    exit
+  fi
 fi
 
 echo "=> Target docker image is $IMAGENAME"
 
-if [ "${NGINX_AGENT}" ]
-then
-	if [ "${NGINX_AGENT_VERSION}" -eq "2" ] || [ "${NGINX_AGENT_VERSION}" -eq "3" ]
-	then
-		echo "=> Building with NGINX Agent v${NGINX_AGENT_VERSION}"
-	else
-		echo "NGINX Agent version must be either '2' or '3'"
-		exit
-	fi
-fi
-
 if ([ ! -z "${NAP_WAF}" ] && [ -z "${NGINX_OSS}" ])
 then
-	echo "=> Building with NGINX App Protect WAF"
-	OPT_PLATFORM="--platform linux/amd64" # for NGINX App Protect WAF, which is only available for x86_64
+  echo "=> Building with NGINX App Protect WAF"
+  OPT_PLATFORM="--platform linux/amd64" # for NGINX App Protect WAF, which is only available for x86_64
 fi
 
 if [ -z "${NGINX_OSS}" ]
 then
-	if [ -z "${UNPRIVILEGED}" ]
-	then
-		DOCKERFILE_NAME=Dockerfile.plus
-		echo "=> Building with NGINX Plus"
-	else
-		DOCKERFILE_NAME=Dockerfile.plus.unprivileged
-		echo "=> Building with NGINX Plus unprivileged"
-	fi
+  if [ -z "${UNPRIVILEGED}" ]
+  then
+    DOCKERFILE_NAME=Dockerfile.plus
+    echo "=> Building with NGINX Plus"
+  else
+    DOCKERFILE_NAME=Dockerfile.plus.unprivileged
+    echo "=> Building with NGINX Plus unprivileged"
+  fi
 
-	DOCKER_BUILDKIT=1 docker build --no-cache -f $DOCKERFILE_NAME \
-		--secret id=nginx-key,src=$NGINX_KEY --secret id=nginx-crt,src=$NGINX_CERT \
-		--build-arg NAP_WAF=$NAP_WAF --build-arg NGINX_AGENT=$NGINX_AGENT \
-		--build-arg NGINX_AGENT_VERSION=$NGINX_AGENT_VERSION \
-		$OPT_PLATFORM \
-		-t $IMAGENAME .
+  echo "=> Using UID:GID $NGINX_UID:$NGINX_GID"
+
+  DOCKER_BUILDKIT=1 docker build --no-cache -f $DOCKERFILE_NAME \
+    --secret id=nginx-key,src=$NGINX_KEY --secret id=nginx-crt,src=$NGINX_CERT \
+    --build-arg NAP_WAF=$NAP_WAF --build-arg NGINX_AGENT=$NGINX_AGENT \
+    --build-arg NGINX_AGENT_VERSION=$NGINX_AGENT_VERSION \
+    --build-arg UID=$NGINX_UID \
+    --build-arg GID=$NGINX_GID \
+    $OPT_PLATFORM \
+    -t $IMAGENAME .
 else
-	echo "=> Building with NGINX Open Source"
-	DOCKER_BUILDKIT=1 docker build --no-cache -f Dockerfile.oss \
-		--build-arg NGINX_AGENT=$NGINX_AGENT \
-		--build-arg NGINX_AGENT_VERSION=$NGINX_AGENT_VERSION \
-		-t $IMAGENAME .
+  echo "=> Building with NGINX Open Source"
+  DOCKER_BUILDKIT=1 docker build --no-cache -f Dockerfile.oss \
+    --build-arg NGINX_AGENT=$NGINX_AGENT \
+    --build-arg NGINX_AGENT_VERSION=$NGINX_AGENT_VERSION \
+    -t $IMAGENAME .
 fi
 
 echo "=> Build complete for $IMAGENAME"

--- a/nginx/docker-image-builder/scripts/build.sh
+++ b/nginx/docker-image-builder/scripts/build.sh
@@ -27,7 +27,7 @@ NGINX Plus, NGINX App Protect WAF and NGINX Agent unprivileged image:\n
   $0 -C nginx-repo.crt -K nginx-repo.key -t registry.ff.lan:31005/nginx-docker:plus-nap-agent-nonroot -w -u -a 2\n\n
 
 NGINX Plus, NGINX App Protect WAF and NGINX Agent unprivileged image, custom UID and GID:\n
-  $0 -C nginx-repo.crt -K nginx-repo.key -t registry.ff.lan:31005/nginx-docker:plus-nap-agent-nonroot -w -u -i 1001770001:1001770001 -a 2\n\n
+  $0 -C nginx-repo.crt -K nginx-repo.key -t registry.ff.lan:31005/nginx-docker:plus-nap-agent-nonroot -w -u -i 1234:1234 -a 2\n\n
 
 NGINX Opensource and NGINX Agent image:\n
   $0 -O -t registry.ff.lan:31005/nginx-docker:oss-root -a 2\n"


### PR DESCRIPTION
### Proposed changes

Added support for custom uid:gid for NGINX Plus unprivileged images. Some users will need to run k8s/openshift pods using the default (high) uid:gid

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [X] If applicable, I have checked that any relevant tests pass after adding my changes.
- [ ] If this is a new demo, I have added the demo info to both the [`CODEOWNERS`](/.github/CODEOWNERS) and [`README.md`](/README.md).
- [X] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
