### PR TITLE
feat: Add NGINX greylist module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@ nginx/api-gateway @alessfg
 nginx/api-steering @aknot242 @fabriziofiorucci
 nginx/docker-image-builder @aknot242 @fabriziofiorucci
 nginx/multicloud-gateway @aknot242 @fabriziofiorucci
+nginx/ngx_http_greylist_module @fabriziofiorucci
 nginx/soap-to-rest @aknot242 @fabriziofiorucci
 nginx-gateway-fabric/traffic-splitting @sjberman
 nginx-ingress-controller/ingress-deployment @nginx/demos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ nginx/api-gateway @alessfg
 nginx/api-steering @aknot242 @fabriziofiorucci
 nginx/docker-image-builder @aknot242 @fabriziofiorucci
 nginx/multicloud-gateway @aknot242 @fabriziofiorucci
-nginx/ngx_http_greylist_module @fabriziofiorucci
+nginx/ngx_http_greylist_module @aknot242 @fabriziofiorucci
 nginx/soap-to-rest @aknot242 @fabriziofiorucci
 nginx-gateway-fabric/traffic-splitting @sjberman
 nginx-ingress-controller/ingress-deployment @nginx/demos

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each demo might have unique deployment requirements. Please refer to each indivi
 |[NGINX API steering](nginx/api-steering/)|NGINX as an API gateway using an external data source for authentication, authorization and steering|@fabriziofiorucci|
 |[NGINX Docker image builder](nginx/docker-image-builder/)|Tool to build several Docker images for NGINX Plus, F5 WAF for NGINX, NGINX Agent|@fabriziofiorucci|
 |[NGINX multicloud gateway](nginx/multicloud-gateway/)|NGINX setup for URI-based kubernetes traffic routing|@fabriziofiorucci|
+|[NGINX greylist module](nginx/ngx_http_greylist_module/)|A native C dynamic module for open-source NGINX that provides pattern-based rate limiting with automatic client greylisting|@fabriziofiorucci|
 |[NGINX SOAP REST](nginx/soap-to-rest/)|Example NGINX configuration to translate between SOAP and REST|@fabriziofiorucci|
 
 ### NGINX Gateway Fabric (NGF)

--- a/nginx/ngx_http_greylist_module/Dockerfile
+++ b/nginx/ngx_http_greylist_module/Dockerfile
@@ -1,0 +1,56 @@
+# =============================================================================
+# Dockerfile — ngx_http_greylist_module
+#
+# Multi-stage build:
+#   builder  — compiles the dynamic module against nginx source
+#   runtime  — minimal nginx image with the compiled .so
+#
+# Usage:
+#   docker build --build-arg NGINX_VER=1.27.4 -t nginx-greylist .
+#   docker run -p 80:80 nginx-greylist
+# =============================================================================
+
+ARG NGINX_VER=1.27.4
+
+# ── Stage 1: builder ──────────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS builder
+
+ARG NGINX_VER
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpcre3-dev    \
+        libssl-dev      \
+        zlib1g-dev      \
+        wget            \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+RUN wget -q "https://nginx.org/download/nginx-${NGINX_VER}.tar.gz" \
+    && tar -xzf "nginx-${NGINX_VER}.tar.gz"
+
+COPY config ./nginx-greylist-module/config
+COPY src/   ./nginx-greylist-module/src/
+
+RUN cd nginx-${NGINX_VER} \
+    && ./configure                                            \
+          --with-compat                                       \
+          --with-http_ssl_module                              \
+          --with-http_v2_module                               \
+          --add-dynamic-module=/build/nginx-greylist-module  \
+    && make modules -j"$(nproc)"                              \
+    && cp objs/ngx_http_greylist_module.so /build/
+
+# ── Stage 2: runtime ──────────────────────────────────────────────────────────
+FROM nginx:${NGINX_VER}
+
+COPY --from=builder /build/ngx_http_greylist_module.so \
+                    /usr/lib/nginx/modules/ngx_http_greylist_module.so
+
+COPY nginx/nginx.conf  /etc/nginx/nginx.conf
+COPY nginx/conf.d/     /etc/nginx/conf.d/
+
+EXPOSE 80 443
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/ngx_http_greylist_module/LICENSE
+++ b/nginx/ngx_http_greylist_module/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright 2025 nginx-greylist-module contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/nginx/ngx_http_greylist_module/README.md
+++ b/nginx/ngx_http_greylist_module/README.md
@@ -1,0 +1,461 @@
+# ngx_http_greylist_module
+
+A **native C dynamic module** for open-source NGINX that provides
+pattern-based rate limiting with automatic client greylisting.
+
+A full reimplementation of
+[fabriziofiorucci/NGINX-Greylist](https://github.com/fabriziofiorucci/NGINX-Greylist)
+that requires **no NGINX Plus**, no NJS, and no `keyval_zone`.
+
+## How it works
+
+```
+  Client request
+       │
+       ▼
+  ┌────────────────────────────────────────────────────────┐
+  │  ACCESS phase  (ngx_http_greylist_module)              │
+  │                                                        │
+  │  1. Compute fingerprint                                │
+  │     IP | FNV32(User-Agent) | FNV32(Bearer-token)       │
+  │                │                                       │
+  │  2. Lookup fingerprint in greylist                     │
+  │     (shared-memory red-black tree)                     │
+  │                │                                       │
+  │      active? ──┴──► 429 + Retry-After                  │
+  │                │                                       │
+  │  3. Find first matching rate-limit rule                │
+  │     subject: "METHOD:scheme://host/uri"                │
+  │                │                                       │
+  │      no match ─┴──► pass through                       │
+  │                │                                       │
+  │  4. Leaky-bucket check  (per client, per rule)         │
+  │                │                                       │
+  │      OK ───────┴──► pass through                       │
+  │                │                                       │
+  │      exceeded ─┴──► write greylist entry (TTL)         │
+  │                      429 + Retry-After                 │
+  └────────────────────────────────────────────────────────┘
+       │
+       ▼
+  proxy_pass → upstream
+```
+
+## Feature parity with the original
+
+| Original (NGINX Plus + NJS)         | This module (open-source NGINX)         |
+|-------------------------------------|-----------------------------------------|
+| `keyval_zone` shared memory         | Slab-allocated shared memory + rbtree   |
+| NJS `clientFingerprint()` (FNV-1a)  | Identical FNV-1a 32-bit hash in C       |
+| `auth_request` greylist check       | Inline ACCESS phase — no subrequest     |
+| NJS `addToGreylist()` on 429        | Same phase, zero overhead               |
+| NJS `denyGreylisted()` response     | `Retry-After` + `X-Greylisted` headers  |
+| `keyval_zone timeout=` (LRU / GC)   | LRU queue + configurable GC timeout     |
+| `limit_req_zone` leaky bucket       | Same algorithm, implemented in C        |
+| NGINX Plus R24+ required            | Open-source NGINX ≥ 1.9.11              |
+| NJS module required                 | No extra modules needed                 |
+
+## Requirements
+
+| Requirement | Version |
+|---|---|
+| NGINX (open-source) | ≥ 1.9.11 |
+| PCRE or PCRE2 | bundled with most distros |
+| OpenSSL | only if using HTTPS |
+
+> **NGINX Plus is not required.**  
+> NJS is not required.
+
+## Installation
+
+### Option A — Build from source
+
+```bash
+# 1. Match the nginx version you are running
+NGINX_VER=$(nginx -v 2>&1 | grep -oP '[\d.]+' | head -n1)
+
+# 2. Download nginx source
+wget https://nginx.org/download/nginx-${NGINX_VER}.tar.gz
+tar -xzf nginx-${NGINX_VER}.tar.gz
+
+# 3. Build only the dynamic module (fast — does not rebuild nginx itself)
+cd nginx-${NGINX_VER}
+./configure \
+    --with-compat          \
+    --with-http_ssl_module \
+    --with-http_v2_module  \
+    --add-dynamic-module=/path/to/nginx-greylist-module
+make modules -j$(nproc)
+
+# 4. Install
+sudo cp objs/ngx_http_greylist_module.so /etc/nginx/modules/
+
+# 5. Validate and reload
+sudo nginx -t && sudo nginx -s reload
+```
+
+> **Important:** Always compile against the exact nginx version you are
+> running. ABI compatibility across major versions is not guaranteed even
+> with `--with-compat`.
+
+### Option B — Docker Compose
+
+```bash
+git clone https://github.com/fabriziofiorucci/ngx_http_greylist_module
+cd ngx_http_greylist_module
+docker compose up --build
+```
+
+The included `Dockerfile` compiles the module and bakes it into the official
+`nginx` image — no manual steps required.
+
+## Quick-start configuration
+
+```nginx
+# nginx.conf ──────────────────────────────────────────────────────────────────
+
+# 1. Load the module (must be before http{})
+load_module modules/ngx_http_greylist_module.so;
+
+http {
+
+    # 2. Create a shared-memory zone
+    greylist_zone  gl  16m  timeout=3600s;
+
+    # 3. Define rate-limit rules
+    greylist_rule  zone=gl
+                   pattern="~*^POST:https?://[^/]+/auth/login"
+                   rate=5r/s
+                   burst=5
+                   duration=120s;
+
+    greylist_rule  zone=gl
+                   pattern="~*^GET:https?://[^/]+/api/search"
+                   rate=30r/m
+                   burst=10
+                   duration=60s;
+
+    server {
+        listen 80;
+
+        location / {
+            # 4. Enable enforcement
+            greylist zone=gl;
+            proxy_pass http://backend;
+        }
+    }
+}
+```
+
+## Directive reference
+
+### `greylist_zone`
+
+```
+Syntax:   greylist_zone <name> <size> [timeout=<N>[s]];
+Context:  http
+```
+
+Creates a named shared-memory zone that holds greylist entries and
+rate-limit token buckets.
+
+| Parameter | Description |
+|---|---|
+| `name` | Identifier used by `greylist_rule` and `greylist` |
+| `size` | Shared memory size — e.g. `16m`. 1 MB ≈ 6 000 entries |
+| `timeout` | Hard GC age for LRU entries (default `3600s`). Set this to at least your longest `duration=` value |
+
+### `greylist_rule`
+
+```
+Syntax:   greylist_rule zone=<name>
+                        pattern="[~[*]]<string>"
+                        rate=<N>r/[sm]
+                        burst=<N>
+                        duration=<N>[s];
+Context:  http
+```
+
+Adds one rate-limit rule to the named zone.
+
+Multiple rules can reference the same zone. Rules are evaluated in order;
+the **first matching rule** per request is applied.
+
+| Parameter | Description |
+|---|---|
+| `zone` | Zone name — must already be defined with `greylist_zone` |
+| `pattern` | Match pattern (see below) |
+| `rate` | Allowed request rate: `5r/s` (per second) or `30r/m` (per minute) |
+| `burst` | Extra requests above the rate before rejection (`0` = no tolerance) |
+| `duration` | How long to greylist an offending client, in seconds (default `60`) |
+
+#### Pattern syntax
+
+The **match subject** built from every request is:
+
+```
+METHOD:scheme://host/uri[?args]
+```
+
+For example: `POST:https://api.example.com/auth/login`
+
+| Prefix | Meaning | Example |
+|---|---|---|
+| `~*` | Case-insensitive PCRE regex | `~*^POST:https?://[^/]+/auth/login` |
+| `~` | Case-sensitive PCRE regex | `~^GET:http://internal\.corp/` |
+| _(none)_ | Exact string match | `GET:http://localhost/ping` |
+
+> **Always quote the pattern value** — e.g. `pattern="~*^POST:..."`.
+> nginx keeps the surrounding `"` when the token starts with `p`; the
+> module strips them automatically.
+
+Common pattern examples:
+
+```nginx
+# Match any host
+pattern="~*^POST:https?://[^/]+/auth/login"
+
+# Match a specific host
+pattern="~*^POST:https?://api\.example\.com/auth/login"
+
+# Match multiple methods
+pattern="~*^(POST|PUT):https?://[^/]+/api/items"
+
+# Exact match (no regex)
+pattern="GET:http://localhost/healthz"
+```
+
+### `greylist`
+
+```
+Syntax:   greylist zone=<name>;
+Context:  http, server, location
+```
+
+Enables the greylist access check in the current context. The `greylist`
+directive can appear in an included file even when `greylist_zone` is
+defined in the outer `nginx.conf` — directive order does not matter.
+
+## Response headers
+
+When a client is rate-limited or greylisted, the module sets:
+
+| Header | Value | Description |
+|---|---|---|
+| `Retry-After` | seconds | Remaining greylist duration |
+| `X-Greylisted` | `1` | Present on every 429 from this module |
+
+You can customise the response body using `error_page`:
+
+```nginx
+error_page 429 @greylisted;
+location @greylisted {
+    default_type application/json;
+    return 429 '{"error":"Too Many Requests","message":"See Retry-After header."}';
+}
+```
+
+## Client fingerprint
+
+Each client is identified by a fingerprint string:
+
+```
+<IP>|<fnv32hex(User-Agent)>|<fnv32hex(Bearer-token)>
+```
+
+Examples:
+```
+10.0.0.5|a1b2c3d4|00000000          # no auth token
+10.0.0.5|a1b2c3d4|cafebabe          # with bearer token
+2001:db8::1|deadbeef|cafebabe       # IPv6
+```
+
+This is identical to the `clientFingerprint()` function in the original
+NJS implementation:
+
+- IP is kept raw for auditability.
+- User-Agent and Bearer token are hashed with FNV-1a 32-bit to bound key
+  length regardless of how long those strings are.
+- Clients behind the same NAT IP but with different User-Agents or tokens
+  are tracked independently.
+- Unauthenticated clients are fingerprinted by IP + UA only (token hash
+  of `""` = `811c9dc5`).
+
+## Auto-expiry
+
+Greylist entries expire through two independent mechanisms — no cron job
+or API call required.
+
+```
+  t=0          t=now >= expiry       t=expiry + timeout
+  ───────────────────────────────────────────────────────►
+  │                    │                        │
+  Written by      Logical expiry:          LRU GC:
+  rate limit      handler evicts           entry freed,
+  exceeded        entry, allows            memory
+                  client through           reclaimed
+```
+
+1. **Logical expiry** — the ACCESS handler compares `ngx_time()` to the
+   stored epoch. Once past, the entry is removed from the rbtree and the
+   client is allowed through immediately.
+
+2. **LRU GC** — when slab memory runs low, the oldest entries are evicted.
+   The `timeout=` parameter on `greylist_zone` sets the maximum age before
+   forced eviction, regardless of expiry.
+
+## Adding a new rule
+
+Example: rate-limit `PUT /api/items` at 10 req/min, greylist 90 s.
+
+**Step 1** — add to `http{}` in `nginx.conf`:
+
+```nginx
+greylist_rule  zone=gl
+               pattern="~*^PUT:https?://[^/]+/api/items"
+               rate=10r/m
+               burst=3
+               duration=90s;
+```
+
+**Step 2** — reload:
+
+```bash
+sudo nginx -t && sudo nginx -s reload
+```
+
+That's it. No location block changes needed — the rule is evaluated
+for every request in any location that has `greylist zone=gl;`.
+
+## Runtime behaviour
+
+### Reload safety
+
+Greylist entries are stored in shared memory and survive a graceful
+`nginx -s reload`. Workers pick up the new configuration while the
+existing greylist remains intact — equivalent to `keyval_zone state=`
+persistence in the original.
+
+### OOM behaviour
+
+If the slab allocator runs out of shared memory, the module **fails open**:
+the request is allowed through and a `WARN` log entry is written. This
+prevents a memory exhaustion from becoming a service outage.
+
+### Worker safety
+
+All shared-memory access is protected by `ngx_shmtx_lock`. PCRE matching
+is performed *outside* the mutex (PCRE is not reentrant under a lock).
+
+## Logging
+
+The module logs at `WARN` level on every block and greylist write. To see
+these messages, set:
+
+```nginx
+error_log /var/log/nginx/error.log warn;
+```
+
+Typical entries:
+
+```
+# Rule matched but within rate limit
+greylist: RL rule=0 excess=500 burst=5000 — pass
+
+# Rate limit exceeded, client greylisted
+greylist: RL rule=0 excess=6000 burst=5000 — BLOCK
+greylist: GREYLISTED fp="10.0.0.5|a1b2c3d4|00000000" rule=0 duration=120s
+
+# Subsequent requests from same client
+greylist: BLOCKED fp="10.0.0.5|a1b2c3d4|00000000" retry_after=118s
+```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `unknown directive "greylist_zone"` | Module not loaded | Add `load_module modules/ngx_http_greylist_module.so;` before `http{}` |
+| `nginx: [emerg] module ... is not binary compatible` | Module built against wrong nginx version | Rebuild against the exact version from `nginx -v` |
+| All requests pass (no 429) | Pattern does not match | Check the `subject=` in warn logs vs your pattern |
+| Pattern never matches | Quotes not stripped or regex typo | Verify pattern with `error_log ... warn;` — logged as `regex "..." vs "..."` |
+| `greylist_rule: zone "X" not found` | Rule defined before zone | Move `greylist_zone` before `greylist_rule`, or just reload (lookup is deferred) |
+| Zone OOM | `size` too small | Increase `greylist_zone` size or decrease `timeout=` |
+
+### Pattern debugging checklist
+
+The match subject is always: `METHOD:scheme://host/uri[?args]`
+
+```
+POST:http://127.0.0.1/auth/login          ← HTTP
+POST:https://api.example.com/auth/login   ← HTTPS
+GET:http://127.0.0.1/api/search?q=foo
+DELETE:https://api.example.com/api/admin/users
+```
+
+Common regex mistakes:
+
+| Wrong | Right | Issue |
+|---|---|---|
+| `http?://` | `https?://` | `?` makes `p` optional, not `s` |
+| `[^/]` | `[^/]+` | matches exactly 1 char, not the whole hostname |
+| `https://` | `https?://` | doesn't match plain HTTP |
+| `pattern=~*^POST` | `pattern="~*^POST"` | must quote the value |
+
+## Testing
+
+```bash
+# Start the demo stack
+docker compose up --build -d
+
+# Run the smoke test suite
+./tests/smoke.sh http://localhost
+
+# Manual test: trigger rate limit
+for i in $(seq 1 10); do
+  printf "Request %2d: " "$i"
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -X POST -H "User-Agent: TestClient/1.0" \
+    http://localhost/auth/login
+done
+# Expected: 200 200 200 200 200 200 429 429 429 429
+#           (6th request exceeds burst=5, gets greylisted)
+
+# Check the Retry-After header
+curl -si -X POST -H "User-Agent: TestClient/1.0" \
+  http://localhost/auth/login | grep -i "retry-after\|x-greylisted"
+
+# Verify a different User-Agent has its own independent counter
+curl -s -o /dev/null -w "%{http_code}\n" \
+  -X POST -H "User-Agent: OtherClient/2.0" \
+  http://localhost/auth/login
+# → 200  (fresh counter for this fingerprint)
+```
+
+## Architecture notes
+
+### Why not use `ngx_http_limit_req_module`?
+
+The standard `limit_req_zone` module provides per-key rate limiting but
+has no concept of greylisting: once a request is rejected the client
+counter resets at the next window and the client can try again
+immediately. This module adds a **persistent penalty period** — the client
+is blocked for `duration=` seconds regardless of how many requests it
+sends.
+
+### Why a native C module instead of NJS?
+
+| | NJS + keyval | This module |
+|---|---|---|
+| NGINX edition | Plus only | Open-source |
+| Extra modules | `ngx_http_js_module`, `ngx_http_auth_request_module` | None |
+| Subrequests | Yes (`auth_request`) | No — inline access phase |
+| Regex engine | NJS built-in | PCRE/PCRE2 (same as nginx) |
+| Shared memory | `keyval_zone` (Plus API) | Slab + rbtree (standard) |
+| Performance | JS interpreter overhead | Native C, zero overhead |
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).
+
+Based on the design of
+[fabriziofiorucci/NGINX-Greylist](https://github.com/fabriziofiorucci/NGINX-Greylist).

--- a/nginx/ngx_http_greylist_module/config
+++ b/nginx/ngx_http_greylist_module/config
@@ -1,0 +1,5 @@
+ngx_module_type=HTTP
+ngx_module_name=ngx_http_greylist_module
+ngx_module_srcs="$ngx_addon_dir/src/ngx_http_greylist_module.c"
+ngx_module_libs=
+. auto/module

--- a/nginx/ngx_http_greylist_module/docker-compose.yml
+++ b/nginx/ngx_http_greylist_module/docker-compose.yml
@@ -1,0 +1,26 @@
+# =============================================================================
+# docker-compose.yml — development / demo stack
+# =============================================================================
+
+services:
+
+  nginx:
+    build:
+      context: .
+      args:
+        NGINX_VER: "1.27.4"
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
+    depends_on:
+      - backend
+    restart: unless-stopped
+
+  backend:
+    image: hashicorp/http-echo:latest
+    command: ["-listen=:8080", "-text=Upstream OK"]
+    expose:
+      - "8080"

--- a/nginx/ngx_http_greylist_module/nginx/conf.d/vhost.conf
+++ b/nginx/ngx_http_greylist_module/nginx/conf.d/vhost.conf
@@ -1,0 +1,64 @@
+# =============================================================================
+# conf.d/vhost.conf — virtual-host configuration
+# =============================================================================
+
+# ── HTTP server ───────────────────────────────────────────────────────────────
+server {
+    listen       80 default_server;
+    server_name  _;
+
+    # Health check — bypasses greylisting (no `greylist` directive here)
+    location = /healthz {
+        access_log off;
+        return 200 "OK\n";
+    }
+
+    # All other locations: enable greylisting
+    location / {
+        # Syntax: greylist zone=<n>;
+        # The module runs in nginx's ACCESS phase:
+        #   1. Check client fingerprint against greylist  → 429 if active
+        #   2. Apply first matching rate-limit rule       → 429 + greylist on excess
+        #   3. Proxy to upstream
+        greylist  zone=gl;
+
+        proxy_pass              http://backend:8080;
+        proxy_http_version      1.1;
+        proxy_set_header        Host              $host;
+        proxy_set_header        X-Real-IP         $remote_addr;
+        proxy_set_header        X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        Connection        "";
+        proxy_connect_timeout   5s;
+        proxy_send_timeout      30s;
+        proxy_read_timeout      30s;
+    }
+
+    # Custom 429 body (optional)
+    error_page 429 @greylisted;
+    location @greylisted {
+        default_type application/json;
+        return 429 '{"error":"Too Many Requests","message":"You have been temporarily greylisted. Check the Retry-After header."}';
+    }
+}
+
+# ── HTTPS server (uncomment and provide certificates) ─────────────────────────
+# server {
+#     listen      443 ssl;
+#     http2       on;
+#     server_name api.example.com;
+#
+#     ssl_certificate      /etc/nginx/ssl/server.crt;
+#     ssl_certificate_key  /etc/nginx/ssl/server.key;
+#     ssl_protocols        TLSv1.2 TLSv1.3;
+#     ssl_ciphers          ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384;
+#     ssl_prefer_server_ciphers off;
+#     ssl_session_cache    shared:SSL:10m;
+#     ssl_session_timeout  1d;
+#
+#     location / {
+#         greylist zone=gl;
+#         proxy_pass http://backend:8080;
+#         ...
+#     }
+# }

--- a/nginx/ngx_http_greylist_module/nginx/nginx.conf
+++ b/nginx/ngx_http_greylist_module/nginx/nginx.conf
@@ -1,0 +1,89 @@
+# =============================================================================
+# nginx.conf — ngx_http_greylist_module example configuration
+# =============================================================================
+
+# Load the module BEFORE the http{} block
+load_module modules/ngx_http_greylist_module.so;
+
+user              nginx;
+worker_processes  auto;
+worker_rlimit_nofile 65535;
+
+error_log  /var/log/nginx/error.log  warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  4096;
+    use                 epoll;
+    multi_accept        on;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr [$time_local] "$request" $status '
+                      'rt=$request_time '
+                      'retry_after=$sent_http_retry_after '
+                      'greylisted=$sent_http_x_greylisted';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile    on;
+    tcp_nopush  on;
+    tcp_nodelay on;
+    keepalive_timeout  65;
+    server_tokens off;
+
+    # -------------------------------------------------------------------------
+    # Greylist shared-memory zone
+    #
+    # Syntax:  greylist_zone <name> <size> [timeout=<N>s];
+    #
+    #   name     Identifier referenced by greylist_rule and greylist.
+    #   size     Shared memory size.  1 MB holds ~6 000 tracked clients.
+    #   timeout  Hard GC age for LRU entries (default 3600 s).
+    #            Set this >= your longest duration= value.
+    # -------------------------------------------------------------------------
+    greylist_zone  gl  16m  timeout=3600s;
+
+    # -------------------------------------------------------------------------
+    # Rate-limit rules
+    #
+    # Syntax:  greylist_rule zone=<name>
+    #                        pattern="[~[*]]<string>"
+    #                        rate=<N>r/[sm]
+    #                        burst=<N>
+    #                        duration=<N>[s];
+    #
+    # Pattern match subject: "METHOD:scheme://host/uri[?args]"
+    #   ~*<regex>  case-insensitive PCRE  (most common)
+    #   ~<regex>   case-sensitive  PCRE
+    #   <string>   exact match
+    #
+    # Rules are evaluated in order; first match wins.
+    # -------------------------------------------------------------------------
+
+    # Rule 1 — brute-force login protection: 5 req/s, greylist 120 s
+    greylist_rule  zone=gl
+                   pattern="~*^POST:https?://[^/]+/auth/login"
+                   rate=5r/s
+                   burst=5
+                   duration=120s;
+
+    # Rule 2 — search / scraping protection: 30 req/min, greylist 60 s
+    greylist_rule  zone=gl
+                   pattern="~*^GET:https?://[^/]+/api/search"
+                   rate=30r/m
+                   burst=10
+                   duration=60s;
+
+    # Rule 3 — destructive admin operations: 2 req/min, greylist 300 s
+    greylist_rule  zone=gl
+                   pattern="~*^DELETE:https?://[^/]+/api/admin"
+                   rate=2r/m
+                   burst=2
+                   duration=300s;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/nginx/ngx_http_greylist_module/src/ngx_http_greylist_module.c
+++ b/nginx/ngx_http_greylist_module/src/ngx_http_greylist_module.c
@@ -1,0 +1,875 @@
+/*
+ * ngx_http_greylist_module.c  —  clean rewrite
+ * See README.md for full documentation.
+ * License: Apache 2.0
+ */
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+#ifndef NGX_HTTP_TOO_MANY_REQUESTS
+#define NGX_HTTP_TOO_MANY_REQUESTS 429
+#endif
+
+#define GL_FP_MAX      128
+#define GL_KEY_MAX     160
+#define GL_MAX_RULES    64
+#define GL_CAP_SLOTS     3
+
+#define GL_TYPE_GL  0
+#define GL_TYPE_RL  1
+
+typedef struct {
+    ngx_str_t     pattern_str;
+#if (NGX_PCRE)
+    ngx_regex_t  *regex;
+    ngx_uint_t    captures;
+    ngx_flag_t    is_regex;
+#endif
+    ngx_uint_t    rate;
+    ngx_uint_t    burst;
+    ngx_uint_t    duration;
+    ngx_uint_t    idx;
+} gl_rule_t;
+
+typedef struct {
+    u_char      color;
+    uint8_t     type;
+    uint8_t     rule_idx;
+    uint8_t     key_len;
+    ngx_queue_t queue;
+    time_t      expiry;
+    ngx_msec_t  last_ms;
+    ngx_uint_t  excess;
+    u_char      key[1];
+} gl_node_t;
+
+typedef struct {
+    ngx_rbtree_t       rbtree;
+    ngx_rbtree_node_t  sentinel;
+    ngx_queue_t        queue;
+    ngx_slab_pool_t   *shpool;
+} gl_shm_t;
+
+typedef struct {
+    ngx_str_t       name;
+    gl_shm_t       *sh;
+    ngx_slab_pool_t *shpool;
+    ngx_shm_zone_t  *shm_zone;
+    ngx_array_t     rules;
+    ngx_uint_t      timeout;
+} gl_zone_t;
+
+typedef struct {
+    ngx_array_t  zones;
+} gl_main_cf_t;
+
+typedef struct {
+    ngx_str_t  zone_name;
+} gl_loc_cf_t;
+
+/* ── forward declarations ────────────────────────────────────────────────── */
+
+static void      *gl_create_main_cf(ngx_conf_t *cf);
+static void      *gl_create_loc_cf(ngx_conf_t *cf);
+static char      *gl_merge_loc_cf(ngx_conf_t *cf, void *parent, void *child);
+static ngx_int_t  gl_init(ngx_conf_t *cf);
+static char      *gl_zone_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char      *gl_rule_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static char      *gl_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf);
+static ngx_int_t  gl_shm_init(ngx_shm_zone_t *shm_zone, void *data);
+static ngx_int_t  gl_handler(ngx_http_request_t *r);
+static gl_zone_t *gl_find_zone(gl_main_cf_t *mcf, ngx_str_t *name);
+static void       gl_rbtree_insert(ngx_rbtree_node_t *temp,
+                      ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel);
+static gl_node_t *gl_lookup(gl_shm_t *sh, ngx_uint_t hash,
+                      const u_char *key, uint8_t klen);
+static void       gl_expire(gl_zone_t *gz, ngx_uint_t n);
+static uint32_t   gl_fnv1a32(const u_char *data, size_t len);
+static size_t     gl_fingerprint(ngx_http_request_t *r, u_char *buf, size_t max);
+static size_t     gl_match_subject(ngx_http_request_t *r, u_char *buf, size_t max);
+static ngx_int_t  gl_match_rule(ngx_http_request_t *r, gl_rule_t *rule,
+                      u_char *sbuf, size_t slen);
+static ngx_int_t  gl_parse_rate(ngx_str_t *s, ngx_uint_t *out);
+static ngx_int_t  gl_parse_duration(ngx_str_t *s, ngx_uint_t *out);
+
+/* ── commands ────────────────────────────────────────────────────────────── */
+
+static ngx_command_t gl_commands[] = {
+    { ngx_string("greylist_zone"),
+      NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE23,
+      gl_zone_directive,
+      NGX_HTTP_MAIN_CONF_OFFSET, 0, NULL },
+
+    { ngx_string("greylist_rule"),
+      NGX_HTTP_MAIN_CONF | NGX_CONF_1MORE,
+      gl_rule_directive,
+      NGX_HTTP_MAIN_CONF_OFFSET, 0, NULL },
+
+    { ngx_string("greylist"),
+      NGX_HTTP_MAIN_CONF | NGX_HTTP_SRV_CONF | NGX_HTTP_LOC_CONF
+      | NGX_CONF_TAKE1,
+      gl_directive,
+      NGX_HTTP_LOC_CONF_OFFSET, 0, NULL },
+
+    ngx_null_command
+};
+
+static ngx_http_module_t gl_module_ctx = {
+    NULL, gl_init,
+    gl_create_main_cf, NULL,
+    NULL, NULL,
+    gl_create_loc_cf, gl_merge_loc_cf
+};
+
+ngx_module_t ngx_http_greylist_module = {
+    NGX_MODULE_V1,
+    &gl_module_ctx, gl_commands, NGX_HTTP_MODULE,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NGX_MODULE_V1_PADDING
+};
+
+/* ── FNV-1a 32-bit ───────────────────────────────────────────────────────── */
+
+static uint32_t
+gl_fnv1a32(const u_char *data, size_t len)
+{
+    uint32_t h = 0x811c9dc5u;
+    while (len--) { h ^= *data++; h *= 0x01000193u; }
+    return h;
+}
+
+/* ── fingerprint: IP|fnv32(UA)|fnv32(token) ──────────────────────────────── */
+
+static size_t
+gl_fingerprint(ngx_http_request_t *r, u_char *buf, size_t max)
+{
+    u_char    *p;
+    uint32_t   ua_h, tok_h;
+    ngx_str_t  ua, auth, token;
+
+    ua = r->headers_in.user_agent
+         ? r->headers_in.user_agent->value
+         : (ngx_str_t) ngx_null_string;
+
+    ngx_str_null(&token);
+    if (r->headers_in.authorization) {
+        auth = r->headers_in.authorization->value;
+        if (auth.len > 7
+            && ngx_strncasecmp(auth.data, (u_char *)"Bearer ", 7) == 0) {
+            token.data = auth.data + 7;
+            token.len  = auth.len  - 7;
+            while (token.len && token.data[0] == ' ')
+                { token.data++; token.len--; }
+        }
+    }
+
+    ua_h  = gl_fnv1a32(ua.data,    ua.len);
+    tok_h = gl_fnv1a32(token.data, token.len);
+    p = ngx_snprintf(buf, max, "%V|%08xD|%08xD",
+                     &r->connection->addr_text, ua_h, tok_h);
+    return (size_t)(p - buf);
+}
+
+/* ── match subject: METHOD:scheme://host/uri ──────────────────────────────── */
+
+static size_t
+gl_match_subject(ngx_http_request_t *r, u_char *buf, size_t max)
+{
+    ngx_str_t  scheme;
+    u_char    *p;
+
+#if (NGX_HTTP_SSL)
+    if (r->connection->ssl) { ngx_str_set(&scheme, "https"); } else { ngx_str_set(&scheme, "http"); }
+#else
+    ngx_str_set(&scheme, "http");
+#endif
+
+    p = ngx_snprintf(buf, max - 1, "%V:%V://%V%V%s%V",
+                     &r->method_name, &scheme,
+                     &r->headers_in.server, &r->uri,
+                     r->args.len ? "?" : "", &r->args);
+    return (size_t)(p - buf);
+}
+
+/* ── pattern matching ────────────────────────────────────────────────────── */
+
+static ngx_int_t
+gl_match_rule(ngx_http_request_t *r, gl_rule_t *rule,
+    u_char *sbuf, size_t slen)
+{
+#if (NGX_PCRE)
+    if (rule->is_regex && rule->regex != NULL) {
+        ngx_str_t  subject;
+        ngx_int_t  rc;
+        int        captures[GL_CAP_SLOTS];
+
+        subject.data = sbuf;
+        subject.len  = slen;
+
+        /*
+         * ngx_regex_exec uses the same PCRE/PCRE2 instance nginx was
+         * compiled against — no cross-library ABI issues.
+         * Returns >= 0 on match, NGX_REGEX_NO_MATCHED (-1) on no match.
+         */
+        rc = ngx_regex_exec(rule->regex, &subject, captures, GL_CAP_SLOTS);
+
+        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+            "greylist: regex \"%V\" vs \"%*s\" rc=%i (%s)",
+            &rule->pattern_str, (int) slen, sbuf, rc,
+            rc >= 0 ? "MATCH" : "no match");
+
+        return (rc >= 0) ? NGX_OK : NGX_DECLINED;
+    }
+#endif
+
+    return (rule->pattern_str.len == slen
+            && ngx_memcmp(rule->pattern_str.data, sbuf, slen) == 0)
+           ? NGX_OK : NGX_DECLINED;
+}
+
+/* ── rbtree ──────────────────────────────────────────────────────────────── */
+
+static void
+gl_rbtree_insert(ngx_rbtree_node_t *temp,
+    ngx_rbtree_node_t *node, ngx_rbtree_node_t *sentinel)
+{
+    ngx_rbtree_node_t **p;
+    gl_node_t          *n, *t;
+
+    for (;;) {
+        n = (gl_node_t *) &node->color;
+        t = (gl_node_t *) &temp->color;
+
+        if      (node->key < temp->key) { p = &temp->left;  }
+        else if (node->key > temp->key) { p = &temp->right; }
+        else {
+            p = (ngx_memn2cmp(n->key, t->key, n->key_len, t->key_len) < 0)
+                ? &temp->left : &temp->right;
+        }
+        if (*p == sentinel) break;
+        temp = *p;
+    }
+
+    *p = node;
+    node->parent = temp;
+    node->left   = sentinel;
+    node->right  = sentinel;
+    ngx_rbt_red(node);
+}
+
+static gl_node_t *
+gl_lookup(gl_shm_t *sh, ngx_uint_t hash, const u_char *key, uint8_t klen)
+{
+    ngx_rbtree_node_t *node = sh->rbtree.root, *sent = &sh->sentinel;
+    ngx_int_t rc;
+    gl_node_t *n;
+
+    while (node != sent) {
+        if      (hash < node->key) { node = node->left;  continue; }
+        else if (hash > node->key) { node = node->right; continue; }
+        n  = (gl_node_t *) &node->color;
+        rc = ngx_memn2cmp((u_char *) key, n->key, klen, n->key_len);
+        if (rc == 0) return n;
+        node = rc < 0 ? node->left : node->right;
+    }
+    return NULL;
+}
+
+static void
+gl_expire(gl_zone_t *gz, ngx_uint_t n)
+{
+    gl_shm_t          *sh  = gz->sh;
+    time_t             now = ngx_time();
+    ngx_queue_t       *q;
+    gl_node_t         *nd;
+    ngx_rbtree_node_t *rbn;
+
+    while (n--) {
+        if (ngx_queue_empty(&sh->queue)) return;
+        q  = ngx_queue_last(&sh->queue);
+        nd = ngx_queue_data(q, gl_node_t, queue);
+
+        if (nd->type == GL_TYPE_GL) {
+            if (now < nd->expiry + (time_t) gz->timeout) return;
+        } else {
+            if (now < (time_t)(nd->last_ms / 1000) + (time_t) gz->timeout)
+                return;
+        }
+
+        ngx_queue_remove(q);
+        rbn = (ngx_rbtree_node_t *)
+              ((u_char *) nd - offsetof(ngx_rbtree_node_t, color));
+        ngx_rbtree_delete(&sh->rbtree, rbn);
+        ngx_slab_free_locked(sh->shpool, rbn);
+    }
+}
+
+/* ── helper: push a response header ──────────────────────────────────────── */
+
+static void
+gl_set_header(ngx_http_request_t *r, const char *key, ngx_str_t *val)
+{
+    ngx_table_elt_t *h = ngx_list_push(&r->headers_out.headers);
+    if (!h) return;
+    h->hash        = 1;
+    h->key.data    = (u_char *) key;
+    h->key.len     = ngx_strlen(key);
+    h->value       = *val;
+    h->lowcase_key = h->key.data;   /* already lowercase */
+}
+
+/* ── access-phase handler ────────────────────────────────────────────────── */
+
+static ngx_int_t
+gl_handler(ngx_http_request_t *r)
+{
+    gl_loc_cf_t        *lcf;
+    gl_main_cf_t       *mcf;
+    gl_zone_t          *gz;
+    gl_shm_t           *sh;
+    gl_rule_t          *rules;
+    gl_node_t          *node;
+    ngx_rbtree_node_t  *rbn;
+
+    u_char      fp[GL_FP_MAX], gl_key[GL_KEY_MAX], rl_key[GL_KEY_MAX];
+    u_char      sbuf[2048];
+    size_t      fp_len, gl_klen, rl_klen, slen;
+    ngx_uint_t  gl_hash, rl_hash, i, matched;
+    ngx_msec_t  now_ms;
+    time_t      now;
+    ngx_int_t   excess;
+    size_t      node_size;
+    ngx_uint_t  retry_after;
+    u_char      ra_buf[NGX_INT_T_LEN];
+    ngx_str_t   ra_str, one;
+
+    lcf = ngx_http_get_module_loc_conf(r, ngx_http_greylist_module);
+    if (lcf->zone_name.len == 0) return NGX_DECLINED;
+
+    mcf = ngx_http_get_module_main_conf(r, ngx_http_greylist_module);
+    gz  = gl_find_zone(mcf, &lcf->zone_name);
+    if (!gz) {
+        ngx_log_error(NGX_LOG_ERR, r->connection->log, 0,
+            "greylist: zone \"%V\" not found", &lcf->zone_name);
+        return NGX_DECLINED;
+    }
+
+    sh    = gz->sh;
+    rules = gz->rules.elts;
+
+    fp_len = gl_fingerprint(r, fp, sizeof(fp));
+    slen   = gl_match_subject(r, sbuf, sizeof(sbuf));
+
+    gl_key[0] = 'G'; gl_key[1] = 'L'; gl_key[2] = ':';
+    ngx_memcpy(gl_key + 3, fp, fp_len);
+    gl_klen = 3 + fp_len;
+    gl_hash = gl_fnv1a32(gl_key, gl_klen);
+
+    /* find matching rule — must be outside the shmtx (PCRE not reentrant) */
+    matched = gz->rules.nelts;
+    for (i = 0; i < gz->rules.nelts; i++) {
+        if (gl_match_rule(r, &rules[i], sbuf, slen) == NGX_OK) {
+            matched = i; break;
+        }
+    }
+
+    ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+        "greylist: zone=\"%V\" rules=%uD subject=\"%*s\" matched=%s "
+        "fp=\"%*s\"",
+        &gz->name, (ngx_uint_t) gz->rules.nelts,
+        (int) slen, sbuf,
+        matched < gz->rules.nelts ? "YES" : "NONE",
+        (int) fp_len, fp);
+
+    now    = ngx_time();
+    now_ms = ngx_current_msec;
+
+    ngx_shmtx_lock(&sh->shpool->mutex);
+
+    /* ── phase 1: greylist check ─────────────────────────────────────── */
+
+    node = gl_lookup(sh, gl_hash, gl_key, (uint8_t) gl_klen);
+    if (node != NULL) {
+        if (now < node->expiry) {
+            retry_after = (ngx_uint_t)(node->expiry - now);
+            ngx_shmtx_unlock(&sh->shpool->mutex);
+            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                "greylist: BLOCKED fp=\"%*s\" retry_after=%uDs",
+                (int) fp_len, fp, retry_after);
+            goto send_429;
+        }
+        /* logically expired — evict */
+        ngx_queue_remove(&node->queue);
+        rbn = (ngx_rbtree_node_t *)
+              ((u_char *) node - offsetof(ngx_rbtree_node_t, color));
+        ngx_rbtree_delete(&sh->rbtree, rbn);
+        ngx_slab_free_locked(sh->shpool, rbn);
+        node = NULL;
+    }
+
+    /* ── phase 2: rate-limit ─────────────────────────────────────────── */
+
+    if (matched == gz->rules.nelts) {
+        ngx_shmtx_unlock(&sh->shpool->mutex);
+        return NGX_DECLINED;
+    }
+
+    i = matched;
+
+    rl_klen = (size_t)(ngx_snprintf(rl_key, sizeof(rl_key),
+                       "RL:%02uD:%*s", i, (int) fp_len, fp) - rl_key);
+    rl_hash = gl_fnv1a32(rl_key, rl_klen);
+
+    node = gl_lookup(sh, rl_hash, rl_key, (uint8_t) rl_klen);
+
+    if (node == NULL) {
+        gl_expire(gz, 1);
+
+        node_size = offsetof(ngx_rbtree_node_t, color)
+                  + offsetof(gl_node_t, key)
+                  + rl_klen;
+
+        rbn = ngx_slab_alloc_locked(sh->shpool, node_size);
+        if (!rbn) {
+            ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+                "greylist: zone \"%V\" OOM, allowing request", &gz->name);
+            ngx_shmtx_unlock(&sh->shpool->mutex);
+            return NGX_DECLINED;
+        }
+
+        node           = (gl_node_t *) &rbn->color;
+        rbn->key       = rl_hash;
+        node->type     = GL_TYPE_RL;
+        node->rule_idx = (uint8_t) i;
+        node->key_len  = (uint8_t) rl_klen;
+        node->excess   = 0;
+        node->last_ms  = now_ms;
+        ngx_memcpy(node->key, rl_key, rl_klen);
+        ngx_rbtree_insert(&sh->rbtree, rbn);
+        ngx_queue_insert_head(&sh->queue, &node->queue);
+
+        /* first request: allow, start tracking from next */
+        ngx_shmtx_unlock(&sh->shpool->mutex);
+        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+            "greylist: RL new node rule=%uD fp=\"%*s\" first-request allowed",
+            i, (int) fp_len, fp);
+        return NGX_DECLINED;
+    }
+
+    /* leaky-bucket */
+    excess = (ngx_int_t) node->excess
+           - (ngx_int_t)(rules[i].rate
+                         * (ngx_msec_int_t)(now_ms - node->last_ms)
+                         / 1000)
+           + 1000;
+
+    if (excess < 0) excess = 0;
+    node->last_ms = now_ms;
+
+    ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+        "greylist: RL rule=%uD excess=%i burst=%uD — %s",
+        i, excess, rules[i].burst,
+        (ngx_uint_t) excess > rules[i].burst ? "BLOCK" : "pass");
+
+    if ((ngx_uint_t) excess > rules[i].burst) {
+        node->excess = (ngx_uint_t) excess;
+        ngx_queue_remove(&node->queue);
+        ngx_queue_insert_head(&sh->queue, &node->queue);
+
+        gl_node_t *gn = gl_lookup(sh, gl_hash, gl_key, (uint8_t) gl_klen);
+        if (!gn) {
+            gl_expire(gz, 1);
+            node_size = offsetof(ngx_rbtree_node_t, color)
+                      + offsetof(gl_node_t, key) + gl_klen;
+            ngx_rbtree_node_t *grbn =
+                ngx_slab_alloc_locked(sh->shpool, node_size);
+            if (grbn) {
+                gn           = (gl_node_t *) &grbn->color;
+                grbn->key    = gl_hash;
+                gn->type     = GL_TYPE_GL;
+                gn->rule_idx = (uint8_t) i;
+                gn->key_len  = (uint8_t) gl_klen;
+                gn->expiry   = now + (time_t) rules[i].duration;
+                ngx_memcpy(gn->key, gl_key, gl_klen);
+                ngx_rbtree_insert(&sh->rbtree, grbn);
+                ngx_queue_insert_head(&sh->queue, &gn->queue);
+            }
+        } else {
+            gn->expiry = now + (time_t) rules[i].duration;
+            ngx_queue_remove(&gn->queue);
+            ngx_queue_insert_head(&sh->queue, &gn->queue);
+        }
+
+        retry_after = rules[i].duration;
+        ngx_shmtx_unlock(&sh->shpool->mutex);
+        ngx_log_error(NGX_LOG_WARN, r->connection->log, 0,
+            "greylist: GREYLISTED fp=\"%*s\" rule=%uD duration=%uDs",
+            (int) fp_len, fp, i, rules[i].duration);
+        goto send_429;
+    }
+
+    node->excess = (ngx_uint_t) excess;
+    ngx_queue_remove(&node->queue);
+    ngx_queue_insert_head(&sh->queue, &node->queue);
+    ngx_shmtx_unlock(&sh->shpool->mutex);
+    return NGX_DECLINED;
+
+send_429:
+    ra_str.data = ra_buf;
+    ra_str.len  = (size_t)(ngx_sprintf(ra_buf, "%uD", retry_after) - ra_buf);
+    gl_set_header(r, "retry-after", &ra_str);
+
+    ngx_str_set(&one, "1");
+    gl_set_header(r, "x-greylisted", &one);
+
+    return NGX_HTTP_TOO_MANY_REQUESTS;
+}
+
+/* ── parse helpers ───────────────────────────────────────────────────────── */
+
+static ngx_int_t
+gl_parse_rate(ngx_str_t *s, ngx_uint_t *out)
+{
+    u_char    *p = s->data, *end = s->data + s->len;
+    size_t     dlen = 0;
+    ngx_int_t  n;
+
+    while (p + dlen < end && p[dlen] >= '0' && p[dlen] <= '9') dlen++;
+    if (!dlen) return NGX_ERROR;
+    n = ngx_atoi(p, dlen);
+    if (n <= 0) return NGX_ERROR;
+    p += dlen;
+
+    if (p >= end || *p++ != 'r') return NGX_ERROR;
+    if (p >= end || *p++ != '/') return NGX_ERROR;
+    if (p >= end)                return NGX_ERROR;
+
+    if      (*p == 's') *out = (ngx_uint_t) n * 1000;
+    else if (*p == 'm') *out = (ngx_uint_t) n * 1000 / 60;
+    else                return NGX_ERROR;
+
+    if (*out == 0) *out = 1;
+    return NGX_OK;
+}
+
+static ngx_int_t
+gl_parse_duration(ngx_str_t *s, ngx_uint_t *out)
+{
+    size_t len = s->len;
+    ngx_int_t n;
+    if (len && s->data[len - 1] == 's') len--;
+    n = ngx_atoi(s->data, len);
+    if (n <= 0) return NGX_ERROR;
+    *out = (ngx_uint_t) n;
+    return NGX_OK;
+}
+
+static gl_zone_t *
+gl_find_zone(gl_main_cf_t *mcf, ngx_str_t *name)
+{
+    ngx_uint_t i;
+    gl_zone_t *z = mcf->zones.elts;
+    for (i = 0; i < mcf->zones.nelts; i++)
+        if (z[i].name.len == name->len
+            && ngx_memcmp(z[i].name.data, name->data, name->len) == 0)
+            return &z[i];
+    return NULL;
+}
+
+/* ── directive handlers ──────────────────────────────────────────────────── */
+
+static char *
+gl_zone_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    gl_main_cf_t   *mcf   = conf;
+    ngx_str_t      *value = cf->args->elts;
+    gl_zone_t      *zone;
+    ngx_shm_zone_t *shm;
+    ssize_t         size;
+    ngx_uint_t      timeout = 3600, i;
+
+    size = ngx_parse_size(&value[2]);
+    if (size < (ssize_t)(8 * ngx_pagesize)) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "greylist_zone: invalid size \"%V\"", &value[2]);
+        return NGX_CONF_ERROR;
+    }
+
+    for (i = 3; i < cf->args->nelts; i++) {
+        if (ngx_strncmp(value[i].data, "timeout=", 8) == 0) {
+            ngx_str_t s = { value[i].len - 8, value[i].data + 8 };
+            if (gl_parse_duration(&s, &timeout) != NGX_OK) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                    "greylist_zone: invalid timeout \"%V\"", &value[i]);
+                return NGX_CONF_ERROR;
+            }
+        } else {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "greylist_zone: unknown parameter \"%V\"", &value[i]);
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    if (gl_find_zone(mcf, &value[1])) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "greylist_zone: \"%V\" already defined", &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    zone = ngx_array_push(&mcf->zones);
+    if (!zone) return NGX_CONF_ERROR;
+    ngx_memzero(zone, sizeof(*zone));
+    zone->name    = value[1];
+    zone->timeout = timeout;
+
+    if (ngx_array_init(&zone->rules, cf->pool, 4, sizeof(gl_rule_t)) != NGX_OK)
+        return NGX_CONF_ERROR;
+
+    shm = ngx_shared_memory_add(cf, &value[1], (size_t) size,
+                                &ngx_http_greylist_module);
+    if (!shm) return NGX_CONF_ERROR;
+    if (shm->data) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "greylist_zone: \"%V\" already defined", &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    shm->init      = gl_shm_init;
+    shm->data      = zone;
+    zone->shm_zone = shm;
+    return NGX_CONF_OK;
+}
+
+static char *
+gl_rule_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    gl_main_cf_t  *mcf   = conf;
+    ngx_str_t     *value = cf->args->elts;
+    gl_zone_t     *zone;
+    gl_rule_t     *rule;
+    ngx_str_t      zone_name, pattern;
+    ngx_uint_t     rate = 0, burst = 0, duration = 60, i;
+
+    ngx_str_null(&zone_name);
+    ngx_str_null(&pattern);
+
+    for (i = 1; i < cf->args->nelts; i++) {
+        if (ngx_strncmp(value[i].data, "zone=", 5) == 0) {
+            zone_name.data = value[i].data + 5;
+            zone_name.len  = value[i].len  - 5;
+
+        } else if (ngx_strncmp(value[i].data, "pattern=", 8) == 0) {
+            pattern.data = value[i].data + 8;
+            pattern.len  = value[i].len  - 8;
+
+            /*
+             * nginx does NOT strip quotes from a token that does not
+             * itself start with '"'.  The token "pattern=..." starts
+             * with 'p', so quotes around the value remain verbatim.
+             * Strip them here.
+             */
+            if (pattern.len >= 2
+                && pattern.data[0] == '"'
+                && pattern.data[pattern.len - 1] == '"')
+            {
+                pattern.data++;
+                pattern.len -= 2;
+            }
+
+        } else if (ngx_strncmp(value[i].data, "rate=", 5) == 0) {
+            ngx_str_t s = { value[i].len - 5, value[i].data + 5 };
+            if (gl_parse_rate(&s, &rate) != NGX_OK) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                    "greylist_rule: invalid rate \"%V\"", &value[i]);
+                return NGX_CONF_ERROR;
+            }
+
+        } else if (ngx_strncmp(value[i].data, "burst=", 6) == 0) {
+            ngx_str_t s  = { value[i].len - 6, value[i].data + 6 };
+            ngx_int_t  n = ngx_atoi(s.data, s.len);
+            if (n < 0) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                    "greylist_rule: invalid burst \"%V\"", &value[i]);
+                return NGX_CONF_ERROR;
+            }
+            burst = (ngx_uint_t) n * 1000;
+
+        } else if (ngx_strncmp(value[i].data, "duration=", 9) == 0) {
+            ngx_str_t s = { value[i].len - 9, value[i].data + 9 };
+            if (gl_parse_duration(&s, &duration) != NGX_OK) {
+                ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                    "greylist_rule: invalid duration \"%V\"", &value[i]);
+                return NGX_CONF_ERROR;
+            }
+
+        } else {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "greylist_rule: unknown parameter \"%V\"", &value[i]);
+            return NGX_CONF_ERROR;
+        }
+    }
+
+    if (!zone_name.len || !pattern.len || !rate) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "greylist_rule: zone=, pattern= and rate= are required");
+        return NGX_CONF_ERROR;
+    }
+
+    zone = gl_find_zone(mcf, &zone_name);
+    if (!zone) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "greylist_rule: zone \"%V\" not found "
+            "(define it first with greylist_zone)", &zone_name);
+        return NGX_CONF_ERROR;
+    }
+
+    if (zone->rules.nelts >= GL_MAX_RULES) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "greylist_rule: too many rules (max %d)", GL_MAX_RULES);
+        return NGX_CONF_ERROR;
+    }
+
+    rule = ngx_array_push(&zone->rules);
+    if (!rule) return NGX_CONF_ERROR;
+    ngx_memzero(rule, sizeof(*rule));
+
+    rule->pattern_str = pattern;
+    rule->rate        = rate;
+    rule->burst       = burst;
+    rule->duration    = duration;
+    rule->idx         = zone->rules.nelts - 1;
+
+#if (NGX_PCRE)
+    if (pattern.len > 0 && pattern.data[0] == '~') {
+        ngx_regex_compile_t  rc;
+        u_char               errstr[NGX_MAX_CONF_ERRSTR];
+        ngx_flag_t           caseless;
+        ngx_str_t            re_str;
+
+        caseless    = (pattern.len > 1 && pattern.data[1] == '*');
+        re_str.data = pattern.data + (caseless ? 2 : 1);
+        re_str.len  = pattern.len  - (caseless ? 2 : 1);
+
+        ngx_memzero(&rc, sizeof(rc));
+        rc.pattern  = re_str;
+        rc.pool     = cf->pool;
+        rc.err.len  = sizeof(errstr);
+        rc.err.data = errstr;
+        rc.options  = caseless ? NGX_REGEX_CASELESS : 0;
+
+        if (ngx_regex_compile(&rc) != NGX_OK) {
+            ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+                "greylist_rule: regex error: %V", &rc.err);
+            return NGX_CONF_ERROR;
+        }
+
+        rule->regex    = rc.regex;
+        rule->captures = (ngx_uint_t) rc.captures;
+        rule->is_regex = 1;
+
+        ngx_conf_log_error(NGX_LOG_NOTICE, cf, 0,
+            "greylist_rule: compiled \"%V\" captures=%uD regex=%p",
+            &pattern, rule->captures, rule->regex);
+    }
+#else
+    if (pattern.len && pattern.data[0] == '~') {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "greylist_rule: regex requires nginx --with-pcre");
+        return NGX_CONF_ERROR;
+    }
+#endif
+
+    return NGX_CONF_OK;
+}
+
+static char *
+gl_directive(ngx_conf_t *cf, ngx_command_t *cmd, void *conf)
+{
+    gl_loc_cf_t  *lcf   = conf;
+    ngx_str_t    *value = cf->args->elts;
+
+    if (ngx_strncmp(value[1].data, "zone=", 5) != 0) {
+        ngx_conf_log_error(NGX_LOG_EMERG, cf, 0,
+            "greylist: expected zone=<n>, got \"%V\"", &value[1]);
+        return NGX_CONF_ERROR;
+    }
+
+    lcf->zone_name.data = value[1].data + 5;
+    lcf->zone_name.len  = value[1].len  - 5;
+    return NGX_CONF_OK;
+}
+
+/* ── module lifecycle ────────────────────────────────────────────────────── */
+
+static ngx_int_t
+gl_shm_init(ngx_shm_zone_t *shm_zone, void *data)
+{
+    gl_zone_t       *zone   = shm_zone->data;
+    gl_zone_t       *ozone  = data;
+    ngx_slab_pool_t *shpool = (ngx_slab_pool_t *) shm_zone->shm.addr;
+    gl_shm_t        *sh;
+
+    if (ozone) {
+        zone->sh     = ozone->sh;
+        zone->shpool = ozone->shpool;
+        return NGX_OK;
+    }
+
+    zone->shpool = shpool;
+    sh = ngx_slab_alloc(shpool, sizeof(*sh));
+    if (!sh) {
+        ngx_log_error(NGX_LOG_EMERG, shm_zone->shm.log, 0,
+            "greylist: zone \"%V\": insufficient shared memory", &zone->name);
+        return NGX_ERROR;
+    }
+
+    zone->sh     = sh;
+    shpool->data = sh;
+    sh->shpool   = shpool;
+    ngx_rbtree_init(&sh->rbtree, &sh->sentinel, gl_rbtree_insert);
+    ngx_queue_init(&sh->queue);
+
+    shpool->log_ctx = ngx_slab_alloc(shpool, zone->name.len + 32);
+    if (shpool->log_ctx)
+        ngx_sprintf(shpool->log_ctx, " in greylist zone \"%V\"%Z", &zone->name);
+
+    return NGX_OK;
+}
+
+static void *
+gl_create_main_cf(ngx_conf_t *cf)
+{
+    gl_main_cf_t *mcf = ngx_pcalloc(cf->pool, sizeof(*mcf));
+    if (!mcf) return NULL;
+    if (ngx_array_init(&mcf->zones, cf->pool, 4, sizeof(gl_zone_t)) != NGX_OK)
+        return NULL;
+    return mcf;
+}
+
+static void *
+gl_create_loc_cf(ngx_conf_t *cf)
+{
+    return ngx_pcalloc(cf->pool, sizeof(gl_loc_cf_t));
+}
+
+static char *
+gl_merge_loc_cf(ngx_conf_t *cf, void *parent, void *child)
+{
+    gl_loc_cf_t *prev = parent, *conf = child;
+    ngx_conf_merge_str_value(conf->zone_name, prev->zone_name, "");
+    return NGX_CONF_OK;
+}
+
+static ngx_int_t
+gl_init(ngx_conf_t *cf)
+{
+    ngx_http_core_main_conf_t *cmcf =
+        ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
+    ngx_http_handler_pt *h =
+        ngx_array_push(&cmcf->phases[NGX_HTTP_ACCESS_PHASE].handlers);
+    if (!h) return NGX_ERROR;
+    *h = gl_handler;
+    return NGX_OK;
+}

--- a/nginx/ngx_http_greylist_module/tests/smoke.sh
+++ b/nginx/ngx_http_greylist_module/tests/smoke.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# =============================================================================
+# tests/smoke.sh — functional smoke tests
+#
+# Usage:
+#   ./tests/smoke.sh [base_url]
+#
+# Requires: curl, grep, seq
+# Default base_url: http://localhost
+# =============================================================================
+set -euo pipefail
+
+BASE="${1:-http://localhost}"
+PASS=0; FAIL=0
+
+green() { printf '\033[32mPASS\033[0m  %s\n' "$*"; }
+red()   { printf '\033[31mFAIL\033[0m  %s\n' "$*"; (( FAIL++ )) || true; }
+
+assert_code() {
+    local label="$1" want="$2"
+    local got
+    got=$(curl -s -o /dev/null -w "%{http_code}" "${@:3}")
+    if [ "$got" = "$want" ]; then
+        green "$label (HTTP $got)"; (( PASS++ )) || true
+    else
+        red   "$label — expected HTTP $want, got HTTP $got"
+    fi
+}
+
+echo "====================================================="
+echo " nginx-greylist-module smoke tests"
+echo " Base: $BASE"
+echo "====================================================="
+
+# T01 — health check always passes
+assert_code "T01 healthz" 200 "$BASE/healthz"
+
+# T02 — normal request passes
+assert_code "T02 normal GET" 200 \
+    -H "User-Agent: SmokeTest-T02-$(date +%s%N)" "$BASE/"
+
+# T03 — POST /auth/login: first request passes
+assert_code "T03 first POST" 200 \
+    -X POST -H "User-Agent: SmokeTest-T03" "$BASE/auth/login"
+
+# T04 — POST /auth/login: rapid burst triggers 429
+echo
+echo "T04: firing 20 rapid POSTs (rate=5r/s burst=5 → should 429)..."
+codes=()
+for i in $(seq 1 20); do
+    codes+=("$(curl -s -o /dev/null -w "%{http_code}" \
+        -X POST -H "User-Agent: SmokeTest-T04" "$BASE/auth/login")")
+done
+printf '  codes: %s\n' "${codes[*]}"
+if printf '%s\n' "${codes[@]}" | grep -q "^429$"; then
+    green "T04 rate limit triggered 429"; (( PASS++ )) || true
+else
+    red   "T04 no 429 received after 20 rapid requests"
+fi
+
+# T05 — greylisted client gets 429 with Retry-After
+echo
+echo "T05: checking Retry-After header..."
+HEADERS=$(curl -si -X POST -H "User-Agent: SmokeTest-T04" "$BASE/auth/login")
+if echo "$HEADERS" | grep -qi "retry-after:"; then
+    green "T05 Retry-After header present"; (( PASS++ )) || true
+else
+    red   "T05 Retry-After header missing"
+fi
+
+# T06 — X-Greylisted header present on 429
+if echo "$HEADERS" | grep -qi "x-greylisted:"; then
+    green "T06 X-Greylisted header present"; (( PASS++ )) || true
+else
+    red   "T06 X-Greylisted header missing"
+fi
+
+# T07 — different User-Agent has independent counter
+FRESH_UA="SmokeTest-T07-fresh-$(date +%s%N)"
+CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST -H "User-Agent: $FRESH_UA" "$BASE/auth/login")
+if [ "$CODE" = "200" ] || [ "$CODE" = "429" ]; then
+    green "T07 distinct UA is independent (HTTP $CODE)"; (( PASS++ )) || true
+else
+    red   "T07 unexpected HTTP $CODE for fresh UA"
+fi
+
+# T08 — GET /api/search rate limit
+echo
+echo "T08: firing 50 rapid GETs to /api/search (rate=30r/m burst=10)..."
+got429=0
+for i in $(seq 1 50); do
+    c=$(curl -s -o /dev/null -w "%{http_code}" \
+        -H "User-Agent: SmokeTest-T08" "$BASE/api/search?q=test")
+    [ "$c" = "429" ] && got429=1 && break
+done
+if [ "$got429" = "1" ]; then
+    green "T08 /api/search rate limit triggered 429"; (( PASS++ )) || true
+else
+    red   "T08 no 429 for /api/search after 50 requests"
+fi
+
+echo
+echo "====================================================="
+printf ' Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+echo "====================================================="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
### Proposed changes

Added native C dynamic module for open-source NGINX that provides pattern-based rate limiting with automatic client greylisting. Works with NGINX open source and NGINX Plus

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [X] If applicable, I have checked that any relevant tests pass after adding my changes.
- [X] If this is a new demo, I have added the demo info to both the [`CODEOWNERS`](/.github/CODEOWNERS) and [`README.md`](/README.md).
- [X] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
