### PR TITLE
feat: Add ngx_http_consul_service_discovery_module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@ nginx/docker-image-builder @aknot242 @fabriziofiorucci
 nginx/multicloud-gateway @aknot242 @fabriziofiorucci
 nginx/ngx_http_greylist_module @aknot242 @fabriziofiorucci
 nginx/ngx_stream_radius_module @aknot242 @fabriziofiorucci
+nginx/ngx_http_consul_service_discovery_module @aknot242 @fabriziofiorucci
 nginx/soap-to-rest @aknot242 @fabriziofiorucci
 nginx-gateway-fabric/traffic-splitting @sjberman
 nginx-ingress-controller/ingress-deployment @nginx/demos

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ Each demo might have unique deployment requirements. Please refer to each indivi
 |[NGINX AI Proxy](nginx/ai-proxy)|Configure NGINX as a simple AI proxy|@pleshakov|
 |[NGINX API gateway](nginx/api-gateway/)|Configure NGINX as an API gateway|@alessfg|
 |[NGINX API steering](nginx/api-steering/)|NGINX as an API gateway using an external data source for authentication, authorization and steering|@fabriziofiorucci|
+|[NGINX Consul service discovery module](nginx/ngx_http_consul_service_discovery_module/)|A native C NGINX module the provides consul service discovery|@fabriziofiorucci|
 |[NGINX Docker image builder](nginx/docker-image-builder/)|Tool to build several Docker images for NGINX Plus, F5 WAF for NGINX, NGINX Agent|@fabriziofiorucci|
-|[NGINX multicloud gateway](nginx/multicloud-gateway/)|NGINX setup for URI-based kubernetes traffic routing|@fabriziofiorucci|
-|[NGINX service discovery](nginx/nginx-service-discovery/)|Consul-compatible service discovery implemented with NGINX + njs|@fabriziofiorucci|
 |[NGINX greylist module](nginx/ngx_http_greylist_module/)|A native C dynamic module for open-source NGINX that provides pattern-based rate limiting with automatic client greylisting|@fabriziofiorucci|
+|[NGINX multicloud gateway](nginx/multicloud-gateway/)|NGINX setup for URI-based kubernetes traffic routing|@fabriziofiorucci|
 |[NGINX RADIUS parser module](nginx/ngx_stream_radius_module/)|A native C NGINX module that parses RADIUS authentication and accounting packets in the stream context, populating NGINX variables with all AVP (Attribute-Value Pair) fields defined in RFC 2865 and RFC 2866, including full Vendor-Specific Attribute (VSA) support with loadable vendor dictionaries|@fabriziofiorucci|
+|[NGINX service discovery](nginx/nginx-service-discovery/)|Consul-compatible service discovery implemented with NGINX + njs|@fabriziofiorucci|
 |[NGINX SOAP REST](nginx/soap-to-rest/)|Example NGINX configuration to translate between SOAP and REST|@fabriziofiorucci|
 
 ### NGINX Gateway Fabric (NGF)

--- a/nginx/ngx_http_consul_service_discovery_module/Dockerfile
+++ b/nginx/ngx_http_consul_service_discovery_module/Dockerfile
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build: compiles NGINX with the consul-service-discovery module
+# and packages a minimal Debian runtime image.
+#
+# Build:
+#   docker build --build-arg NGINX_VER=1.26.1 -t ngx-consul-discovery .
+#
+# Run:
+#   docker run --rm -p 8080:8080 ngx-consul-discovery
+#   curl http://localhost:8080/consul/services
+
+ARG NGINX_VER=1.26.1
+
+# ── Stage 1: builder ──────────────────────────────────────────────────────
+FROM debian:bookworm-slim AS builder
+ARG NGINX_VER
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential libpcre3-dev zlib1g-dev libssl-dev curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+RUN curl -fsSLo nginx.tar.gz \
+        "https://nginx.org/download/nginx-${NGINX_VER}.tar.gz" \
+    && tar -xzf nginx.tar.gz && rm nginx.tar.gz
+
+COPY config    /build/module/config
+COPY src/      /build/module/src/
+
+RUN cd nginx-${NGINX_VER} && \
+    ./configure \
+        --prefix=/etc/nginx \
+        --sbin-path=/usr/sbin/nginx \
+        --conf-path=/etc/nginx/nginx.conf \
+        --error-log-path=/var/log/nginx/error.log \
+        --http-log-path=/var/log/nginx/access.log \
+        --pid-path=/var/run/nginx.pid \
+        --with-http_ssl_module \
+        --with-http_v2_module \
+        --add-module=/build/module \
+        --with-cc-opt='-O2 -pipe' && \
+    make -j"$(nproc)" && \
+    make install
+
+# ── Stage 2: runtime ──────────────────────────────────────────────────────
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libpcre3 zlib1g libssl3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/log/nginx /var/cache/nginx
+
+COPY --from=builder /usr/sbin/nginx   /usr/sbin/nginx
+COPY --from=builder /etc/nginx        /etc/nginx
+COPY examples/example.conf            /etc/nginx/nginx.conf
+
+EXPOSE 8080
+STOPSIGNAL SIGQUIT
+CMD ["nginx", "-g", "daemon off;"]

--- a/nginx/ngx_http_consul_service_discovery_module/LICENSE
+++ b/nginx/ngx_http_consul_service_discovery_module/LICENSE
@@ -1,0 +1,17 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+Copyright 2025 nginx-greylist-module contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/nginx/ngx_http_consul_service_discovery_module/Makefile
+++ b/nginx/ngx_http_consul_service_discovery_module/Makefile
@@ -1,0 +1,41 @@
+# Makefile — ngx_http_consul_service_discovery
+#
+# Usage:
+#   make static  NGINX_SRC=/path/to/nginx  — static build (linked into nginx binary)
+#   make dynamic NGINX_SRC=/path/to/nginx  — dynamic (.so) build
+#   make test    NGINX_SRC=/path/to/nginx  — build + run smoke tests
+#   make clean   NGINX_SRC=/path/to/nginx  — remove build artefacts
+
+NGINX_SRC  ?= /usr/local/src/nginx
+MODULE_DIR := $(shell pwd)
+
+.PHONY: all static dynamic test clean
+
+all: dynamic
+
+static:
+	@echo "==> Configuring static module into NGINX at $(NGINX_SRC)"
+	cd $(NGINX_SRC) && ./configure \
+		--with-http_ssl_module \
+		--with-http_v2_module \
+		--add-module=$(MODULE_DIR)
+	$(MAKE) -C $(NGINX_SRC)
+
+dynamic:
+	@echo "==> Building dynamic module (NGINX at $(NGINX_SRC))"
+	cd $(NGINX_SRC) && ./configure \
+		--with-compat \
+		--with-http_ssl_module \
+		--with-http_v2_module \
+		--add-dynamic-module=$(MODULE_DIR)
+	$(MAKE) -C $(NGINX_SRC) modules
+	@echo ""
+	@echo "==> Module built: $(NGINX_SRC)/objs/ngx_http_consul_service_discovery_module.so"
+
+test: static
+	bash $(MODULE_DIR)/t/smoke.sh \
+		$(NGINX_SRC)/objs/nginx \
+		$(MODULE_DIR)/t/nginx.conf
+
+clean:
+	$(MAKE) -C $(NGINX_SRC) clean 2>/dev/null || true

--- a/nginx/ngx_http_consul_service_discovery_module/README.md
+++ b/nginx/ngx_http_consul_service_discovery_module/README.md
@@ -1,0 +1,551 @@
+# ngx_http_consul_service_discovery_module
+
+A native C NGINX module that exposes selected `server {}` blocks as a JSON
+service catalogue via a configurable location endpoint.  It does **not** talk
+to Consul directly; a sidecar, cron job, or Consul agent can poll the endpoint
+and register/deregister services through the
+[Consul HTTP API](https://developer.hashicorp.com/consul/api-docs/agent/service).
+
+**Port and address are discovered automatically** from the `listen` and
+`server_name` directives — no manual override directives are required for
+standard deployments.
+
+Compatible with **NGINX Open Source ≥ 1.13** (static and dynamic module builds).
+
+---
+
+## Table of Contents
+
+1. [Features](#features)
+2. [How Auto-Discovery Works](#how-auto-discovery-works)
+3. [Architecture](#architecture)
+4. [Quick Start](#quick-start)
+5. [Build Instructions](#build-instructions)
+   - [Static Module](#static-module)
+   - [Dynamic Module](#dynamic-module)
+6. [Directives Reference](#directives-reference)
+7. [JSON Response Format](#json-response-format)
+8. [Configuration Examples](#configuration-examples)
+9. [Testing](#testing)
+10. [Security Considerations](#security-considerations)
+11. [Known Limitations](#known-limitations)
+12. [References](#references)
+13. [License](#license)
+
+---
+
+## Features
+
+- **Automatic port discovery** — the module walks `cmcf->ports` at
+  postconfiguration time to read each server's listen port directly from the
+  parsed `listen` directive; no `consul_service_port_override` required
+- **Automatic address discovery** — the `address` field in the JSON is
+  populated from the primary `server_name` value (FQDN or IP literal)
+- **NAT / load-balancer friendly** — `consul_service_port_override` is
+  available to advertise an external port that differs from the NGINX listen
+  port, while the address is still auto-discovered
+- **Zero Consul dependency** — expose service metadata from NGINX config alone
+- **Standard NGINX build system** — static (`--add-module`) and dynamic
+  (`--add-dynamic-module`) builds supported
+- **JSON catalogue endpoint** — any location can serve
+  `GET /consul/services`; restrict access with `allow`/`deny`
+- **Static snapshot** — catalogue is built once at startup in the
+  postconfiguration phase; request handling is a plain array walk with no
+  parsing overhead
+
+---
+
+## How Auto-Discovery Works
+
+### Port
+
+During the NGINX configuration parse, every `listen` directive causes the core
+module to call `ngx_http_add_listen()`, which inserts an entry into
+`cmcf->ports` — a flat array of `ngx_http_conf_port_t` structs (one per unique
+port number).  Each port entry holds an `addrs` array; each address holds a
+`servers` array of `ngx_http_core_srv_conf_t *` pointers for every virtual
+server listening on that address:port.
+
+```
+cmcf->ports[]                    (ngx_http_conf_port_t)
+  .port  ← host-byte-order port  (ngx_inet_get_port applies ntohs)
+  .addrs[]                       (ngx_http_conf_addr_t)
+    .opt.addr_text  ← "IP:port"
+    .servers[]      ← ngx_http_core_srv_conf_t *  ← matched by pointer
+```
+
+NGINX calls all `postconfiguration` hooks (line 309 in `ngx_http.c`) **before**
+it calls `ngx_http_optimize_servers()` (line 335), which means `cmcf->ports`
+and its nested arrays are still fully populated on `cf->temp_pool` when our
+hook runs.
+
+The module's `ngx_http_consul_find_listen_port()` iterates
+`ports → addrs → servers[]` and compares each `ngx_http_core_srv_conf_t *`
+against the target by pointer equality.  When a match is found it returns
+`ports[p].port` — already in host byte order.
+
+### Address
+
+The `address` field is the bind IP from the `listen` directive, obtained by
+calling `ngx_sock_ntop(opt.sockaddr, opt.socklen, buf, len, 0)` on the matched
+`ngx_http_conf_addr_t`.  The `port=0` argument produces bare IP text with no
+port suffix (`opt.addr_text` includes the port — this call does not).
+
+| `listen` directive | `address` in JSON |
+|--------------------|-------------------|
+| `listen 80;` | `"0.0.0.0"` |
+| `listen 0.0.0.0:80;` | `"0.0.0.0"` |
+| `listen 1.2.3.4:80;` | `"1.2.3.4"` |
+| `listen [::]:80;` | `"::"` |
+| `listen [::1]:443;` | `"::1"` |
+| `listen 127.0.0.1:8080;` | `"127.0.0.1"` |
+
+The text buffer (`NGX_SOCKADDR_STRLEN` bytes) is allocated on `cf->pool`
+(permanent pool) and remains valid for the worker lifetime.
+
+---
+
+## Architecture
+
+```
+NGINX config parse
+  │  every listen directive → ngx_http_add_listen()
+  │  every server_name     → cscf->server_name
+  ▼
+postconfiguration hook  (before ngx_http_optimize_servers)
+  │  ngx_http_consul_find_listen_port():
+  │    walk cmcf->ports → addrs → servers[]
+  │    match cscf by pointer → read port (host byte order)
+  │  ngx_sock_ntop(opt.sockaddr, port=0) → IP-only address text
+  ▼
+in-memory service catalogue  (ngx_array_t in main conf, permanent pool)
+  │
+  ▼  GET /consul/services
+JSON response ──► Consul agent / sidecar / external poller
+                        │
+                        ▼
+                  PUT /v1/agent/service/register
+```
+
+---
+
+## Quick Start
+
+```nginx
+http {
+
+    # ── Discovery endpoint ───────────────────────────────────────────────
+    server {
+        listen 8080;
+        server_name discovery.internal;
+
+        location /consul/services {
+            consul_service_discovery on;
+        }
+    }
+
+    # ── A discoverable service ───────────────────────────────────────────
+    # Port (443) and address (api.example.com) are discovered automatically.
+    server {
+        listen 443 ssl;
+        server_name api.example.com;
+
+        consul_service_discoverable on;
+        consul_service_name         "my-api";
+        consul_service_tags         "v2,production,https";
+
+        ssl_certificate     /etc/ssl/cert.pem;
+        ssl_certificate_key /etc/ssl/key.pem;
+
+        location / { proxy_pass http://backend; }
+    }
+}
+```
+
+```bash
+curl -s http://discovery.internal:8080/consul/services | jq .
+```
+
+```json
+{
+  "services": [
+    {
+      "name": "my-api",
+      "address": "0.0.0.0",
+      "port": 443,
+      "tags": "v2,production,https"
+    }
+  ]
+}
+```
+
+---
+
+## Build Instructions
+
+### Prerequisites
+
+- NGINX source tree (same version as the installed binary for dynamic builds)
+- GCC or Clang
+- PCRE, OpenSSL, zlib development headers (standard NGINX dependencies)
+
+
+### Dynamic Module (Recommended)
+
+#### 1. Download the NGINX source matching your installed version
+```bash
+nginx_version=$(nginx -v 2>&1 | grep -oP '[\d.]+' | head -n1)
+wget https://nginx.org/download/nginx-${nginx_version}.tar.gz
+tar xzf nginx-${nginx_version}.tar.gz
+```
+
+#### 2. Clone this module
+```bash
+git clone https://github.com/nginx/nginx-demos.git
+```
+
+#### 3. Configure with --add-dynamic-module
+```bash
+cd nginx-${nginx_version}
+./configure \
+    --with-compat          \
+    --with-http_ssl_module \
+    --with-http_v2_module  \
+    --add-dynamic-module=../nginx-demos/nginx/ngx_http_consul_service_discovery_module
+```
+
+#### 4. Build only the module (fast)
+```bash
+make modules -j$(nproc)
+```
+
+#### 5. Install
+```bash
+sudo cp objs/ngx_http_consul_service_discovery_module.so /etc/nginx/modules/
+```
+
+#### 6. Add to nginx.conf (top level, before events {})
+```bash
+load_module modules/ngx_http_consul_service_discovery_module.so;
+```
+
+### Static Module
+
+```bash
+nginx_version=$(nginx -v 2>&1 | grep -oP '[\d.]+' | head -n1)
+cd nginx-${nginx_version}
+./configure \
+    --with-compat          \
+    --with-http_ssl_module \
+    --with-http_v2_module  \
+    --add-module=../nginx-demos/nginx/ngx_http_consul_service_discovery_module
+make -j$(nproc)
+sudo make install
+```
+
+### Makefile targets
+
+```bash
+make static  NGINX_SRC=/path/to/nginx   # build static
+make dynamic NGINX_SRC=/path/to/nginx   # build dynamic .so (default)
+make test    NGINX_SRC=/path/to/nginx   # build + run smoke tests
+make clean   NGINX_SRC=/path/to/nginx   # remove build artefacts
+```
+
+### Docker
+
+```bash
+docker build -t ngx-consul-discovery .
+docker run --rm -p 8080:8080 ngx-consul-discovery
+curl http://localhost:8080/consul/services
+```
+
+---
+
+## Directives Reference
+
+### `consul_service_discovery`
+
+**Syntax:** `consul_service_discovery on | off;`  
+**Default:** `off`  
+**Context:** `location`
+
+Enables the JSON catalogue endpoint for this location.  `GET` returns the full
+service list as JSON; `HEAD` returns only headers.
+
+```nginx
+location /consul/services {
+    consul_service_discovery on;
+}
+```
+
+---
+
+### `consul_service_discoverable`
+
+**Syntax:** `consul_service_discoverable on | off;`  
+**Default:** `off`  
+**Context:** `server`
+
+Marks this virtual server as a discoverable service.  Only server blocks with
+this directive set to `on` appear in the JSON catalogue.
+
+---
+
+### `consul_service_name`
+
+**Syntax:** `consul_service_name "<name>";`  
+**Default:** first `server_name` value  
+**Context:** `server`
+
+Logical service name in the JSON `name` field.  When omitted the first
+`server_name` value is used.
+
+---
+
+### `consul_service_tags`
+
+**Syntax:** `consul_service_tags "<tag1,tag2,...>";`  
+**Default:** `"nginx"`  
+**Context:** `server`
+
+Comma-separated tag string in the JSON `tags` field.  Tag semantics are
+defined by the consumer; the module treats them as opaque.
+
+---
+
+### `consul_service_port_override`
+
+**Syntax:** `consul_service_port_override <port>;`  
+**Default:** *(port auto-discovered from* `listen` *directive)*  
+**Context:** `server`
+
+**Optional.** Overrides the auto-discovered listen port in the JSON catalogue.
+Use this only when the external port consumers should connect to differs from
+the NGINX listen port — for example, behind NAT or a public load balancer.
+
+```nginx
+# NGINX listens on 8443 internally; public LB exposes :443
+server {
+    listen 8443 ssl;
+    server_name api.example.com;          # address auto-discovered
+
+    consul_service_discoverable  on;
+    consul_service_name          "api";
+    consul_service_port_override 443;     # override only the port
+}
+```
+
+When not set, the port is read directly from the `listen` directive.
+
+---
+
+## JSON Response Format
+
+`GET /consul/services` → `200 OK`, `Content-Type: application/json`:
+
+```json
+{
+  "services": [
+    {
+      "name":    "api1",
+      "address": "api1.example.com",
+      "port":    80,
+      "tags":    "v1,public"
+    },
+    {
+      "name":    "api2",
+      "address": "api2.example.com",
+      "port":    443,
+      "tags":    "v2,https"
+    }
+  ]
+}
+```
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `name` | `consul_service_name` or first `server_name` | |
+| `address` | bind IP from the `listen` directive | `"0.0.0.0"` for wildcard; specific IP for bound addresses |
+| `port` | `listen` directive, or `consul_service_port_override` | host byte order |
+| `tags` | `consul_service_tags` or `"nginx"` | comma-separated string |
+
+---
+
+## Configuration Examples
+
+### Standard setup — no overrides needed
+
+Port and address are fully automatic:
+
+```nginx
+http {
+    server {
+        listen 8080;
+        server_name discovery.internal;
+
+        location /consul/services {
+            consul_service_discovery on;
+            allow 10.0.0.0/8;
+            deny  all;
+        }
+    }
+
+    server {
+        listen 80;
+        server_name api1.example.com;
+
+        consul_service_discoverable on;
+        consul_service_name         "api1";
+        consul_service_tags         "v1,http";
+
+        location / { proxy_pass http://api1-backend; }
+    }
+
+    server {
+        listen 443 ssl;
+        server_name api2.example.com;
+
+        consul_service_discoverable on;
+        consul_service_name         "api2";
+        consul_service_tags         "v1,https";
+
+        ssl_certificate     /etc/ssl/api2.crt;
+        ssl_certificate_key /etc/ssl/api2.key;
+
+        location / { proxy_pass http://api2-backend; }
+    }
+}
+```
+
+Result:
+```json
+{"services":[
+  {"name":"api1","address":"0.0.0.0","port":80,"tags":"v1,http"},
+  {"name":"api2","address":"0.0.0.0","port":443,"tags":"v1,https"}
+]}
+```
+
+### NAT / load-balancer port override
+
+Only the port needs overriding; the address is still auto-discovered:
+
+```nginx
+server {
+    listen      8080;
+    server_name internal-svc.corp;
+
+    consul_service_discoverable  on;
+    consul_service_name          "internal-svc";
+    consul_service_tags          "v2,internal";
+    consul_service_port_override 80;   # LB maps :80 → :8080 internally
+}
+```
+
+Result:
+```json
+{"services":[
+  {"name":"internal-svc","address":"0.0.0.0","port":80,"tags":"v2,internal"}
+]}
+```
+
+### Consul agent sidecar registration script
+
+```bash
+#!/usr/bin/env bash
+# register-services.sh — poll the NGINX catalogue and register in Consul
+
+DISCOVERY_URL="http://127.0.0.1:8080/consul/services"
+CONSUL_URL="http://127.0.0.1:8500/v1/agent/service/register"
+
+curl -sf "$DISCOVERY_URL" | jq -c '.services[]' | while read -r svc; do
+    name=$(echo "$svc" | jq -r '.name')
+    addr=$(echo "$svc" | jq -r '.address')
+    port=$(echo "$svc" | jq -r '.port')
+    tags=$(echo "$svc" | jq -r '.tags | split(",") | map(ltrimstr(" "))')
+
+    curl -sf -X PUT "$CONSUL_URL" \
+        -H "Content-Type: application/json" \
+        -d "{
+              \"Name\":    \"$name\",
+              \"Address\": \"$addr\",
+              \"Port\":    $port,
+              \"Tags\":    $tags
+            }"
+
+    echo "Registered: $name at $addr:$port"
+done
+```
+
+---
+
+## Testing
+
+```bash
+make test NGINX_SRC=/path/to/nginx-1.26.1
+```
+
+The smoke test (`t/smoke.sh`) verifies:
+
+1. `nginx -t` config validation passes
+2. NGINX starts and the discovery endpoint responds
+3. Both services appear in the JSON by name
+4. Ports are correctly auto-discovered from `listen` (no overrides in test config)
+5. Addresses are correctly auto-discovered from `server_name`
+6. `Content-Type: application/json` header is set
+7. Response has `{"services":[...]}` top-level shape
+
+---
+
+## Security Considerations
+
+1. **Restrict the discovery endpoint.**  It exposes service names, FQDNs, and
+   ports.  Limit access to trusted networks:
+
+   ```nginx
+   location /consul/services {
+       consul_service_discovery on;
+       allow 10.0.0.0/8;
+       allow 127.0.0.1;
+       deny  all;
+   }
+   ```
+
+2. **Do not expose the endpoint on a public interface.**  Bind the discovery
+   server block to a management IP or dedicated VLAN.
+
+3. **`server_name` values are config-controlled strings.**  Do not embed
+   credentials or sensitive data in `server_name` or `consul_service_tags`.
+
+4. **The catalogue is a startup snapshot.**  After `nginx -s reload` the
+   postconfiguration hook re-runs and the catalogue is refreshed automatically.
+
+5. **No authentication on the endpoint itself.**  If mTLS is required, place
+   the discovery server block behind an SSL listener with `ssl_verify_client on`.
+
+---
+
+## Known Limitations
+
+| Limitation | Workaround |
+|-----------|-----------|
+| If a server has no `listen` directive, `port` is `0` and a `[warn]` line is emitted | Add an explicit `listen` or set `consul_service_port_override` |
+| If a server listens on multiple ports, the first match in `cmcf->ports` is used | Set `consul_service_port_override` to select a specific port |
+| If a server has no `listen` and no default port, `address` is `""` and `port` is `0` | Add an explicit `listen` directive |
+| If a server listens on multiple addresses, the first match in `cmcf->ports` is used for the address | Set `consul_service_port_override` to clarify intent; address ambiguity has no override |
+| Catalogue refreshes only on `nginx -s reload` | Automate reloads or run a sidecar that handles dynamic registration |
+
+---
+
+## References
+
+- [Consul HTTP API — Service Registration](https://developer.hashicorp.com/consul/api-docs/agent/service)
+- [NGINX HTTP Module Development Guide](https://nginx.org/en/docs/dev/development_guide.html)
+- [NGINX `ngx_http_core_module` source — `ngx_http_add_listen`](https://github.com/nginx/nginx/blob/master/src/http/ngx_http.c)
+- [`ngx_inet_get_port` — port byte-order conversion](https://github.com/nginx/nginx/blob/master/src/core/ngx_inet.c)
+
+---
+
+## License
+
+Apache 2.0 — see [LICENSE](LICENSE).

--- a/nginx/ngx_http_consul_service_discovery_module/config
+++ b/nginx/ngx_http_consul_service_discovery_module/config
@@ -1,0 +1,5 @@
+ngx_module_type=HTTP
+ngx_module_name=ngx_http_consul_service_discovery_module
+ngx_module_srcs="$ngx_addon_dir/src/ngx_http_consul_service_discovery_module.c"
+ngx_module_libs=
+. auto/module

--- a/nginx/ngx_http_consul_service_discovery_module/examples/example.conf
+++ b/nginx/ngx_http_consul_service_discovery_module/examples/example.conf
@@ -1,0 +1,108 @@
+# example.conf — ngx_http_consul_service_discovery
+#
+# Automatic discovery behaviour:
+#
+#   address — the bind IP from the listen directive, via ngx_sock_ntop.
+#             "listen 80" and "listen 0.0.0.0:80" both give "0.0.0.0".
+#             "listen 1.2.3.4:80" gives "1.2.3.4".
+#
+#   port    — the port from the listen directive.
+#             consul_service_port_override overrides it for NAT scenarios.
+#
+# Expected JSON from GET /consul/services:
+#
+#   {"services":[
+#     {"name":"api1","address":"0.0.0.0","port":80,"tags":"v1,public,http"},
+#     {"name":"api2","address":"0.0.0.0","port":80,"tags":"v2,admin,nat"},
+#     {"name":"api3","address":"1.2.3.4","port":8443,"tags":"v1,https"}
+#   ]}
+#
+# Start with:
+#   nginx -c /path/to/example.conf -p /path/to/nginx-source/
+# Query:
+#   curl http://localhost:8080/consul/services | jq .
+
+error_log  logs/error.log warn;
+pid        logs/nginx.pid;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+
+    # ── Service Discovery Endpoint ───────────────────────────────────────
+    server {
+        listen      8080;
+        server_name discovery.internal;
+
+        location /consul/services {
+            consul_service_discovery on;
+
+            # allow 10.0.0.0/8;
+            # deny  all;
+        }
+
+        location /healthz {
+            return 200 "ok\n";
+            add_header Content-Type text/plain;
+        }
+    }
+
+    # ── api1: plain HTTP, wildcard bind ──────────────────────────────────
+    # listen 80 → address "0.0.0.0", port 80.  No overrides needed.
+    server {
+        listen      80;
+        server_name api1.example.com;
+
+        consul_service_discoverable on;
+        consul_service_name         "api1";
+        consul_service_tags         "v1,public,http";
+
+        location / {
+            return 200 "API 1\n";
+            add_header Content-Type text/plain;
+        }
+    }
+
+    # ── api2: behind NAT / load-balancer ─────────────────────────────────
+    # NGINX listens on 8081 internally; the public LB exposes :80.
+    # consul_service_port_override advertises port 80.
+    # Address is still auto-discovered from the listen directive → "0.0.0.0".
+    server {
+        listen      8081;
+        server_name api2.example.com;
+
+        consul_service_discoverable  on;
+        consul_service_name          "api2";
+        consul_service_tags          "v2,admin,nat";
+        consul_service_port_override 80;
+
+        location / {
+            return 200 "API 2\n";
+            add_header Content-Type text/plain;
+        }
+    }
+
+    # ── api3: specific IP bind + SSL ─────────────────────────────────────
+    # listen 1.2.3.4:8443 → address "1.2.3.4", port 8443.
+    # Uncomment and supply valid certificate paths to enable TLS.
+    #
+    # server {
+    #     listen      1.2.3.4:8443 ssl;
+    #     server_name api3.example.com;
+    #
+    #     consul_service_discoverable on;
+    #     consul_service_name         "api3";
+    #     consul_service_tags         "v1,https";
+    #
+    #     ssl_certificate     /etc/nginx/ssl/api3.crt;
+    #     ssl_certificate_key /etc/nginx/ssl/api3.key;
+    #     ssl_protocols       TLSv1.2 TLSv1.3;
+    #
+    #     location / {
+    #         return 200 "API 3\n";
+    #         add_header Content-Type text/plain;
+    #     }
+    # }
+}

--- a/nginx/ngx_http_consul_service_discovery_module/src/ngx_http_consul_service_discovery.h
+++ b/nginx/ngx_http_consul_service_discovery_module/src/ngx_http_consul_service_discovery.h
@@ -1,0 +1,81 @@
+/*
+ * ngx_http_consul_service_discovery.h
+ *
+ * Public header for the NGINX Consul Service Discovery module.
+ * Include this file from the module implementation and any companion modules
+ * that need to inspect the service catalogue.
+ *
+ * Copyright (c) 2024 – present, Contributors
+ * Licensed under the MIT License.  See LICENSE for details.
+ */
+
+#ifndef _NGX_HTTP_CONSUL_SERVICE_DISCOVERY_H_INCLUDED_
+#define _NGX_HTTP_CONSUL_SERVICE_DISCOVERY_H_INCLUDED_
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+
+#define NGX_HTTP_CONSUL_DISCOVERY_MODULE  "ngx_http_consul_service_discovery"
+#define NGX_HTTP_CONSUL_DISCOVERY_VERSION "1.1.0"
+
+
+/*
+ * Per-server{} configuration.
+ *
+ * Directives: consul_service_discoverable, consul_service_name,
+ *             consul_service_tags, consul_service_port_override.
+ *
+ * Port and address are now auto-discovered:
+ *   port    — read from the listen directive at postconfiguration time by
+ *             walking cmcf->ports; consul_service_port_override overrides it.
+ *   address — taken from the first server_name value (cscf->server_name).
+ */
+typedef struct {
+    ngx_flag_t   discoverable;    /* consul_service_discoverable on|off      */
+    ngx_str_t    service_name;    /* consul_service_name "<name>"            */
+    ngx_str_t    tags;            /* consul_service_tags "t1,t2,..."         */
+    ngx_uint_t   port_override;   /* consul_service_port_override <port>     */
+} ngx_http_consul_service_discovery_srv_conf_t;
+
+
+/*
+ * A single snapshotted service entry collected at postconfiguration time.
+ * Stored in the main conf's services array.
+ *
+ * Fields:
+ *   name — consul_service_name, or first server_name value
+ *   addr — bind IP from the listen directive ("0.0.0.0", "1.2.3.4", "::", etc.)
+ *   port — port from the listen directive, or consul_service_port_override
+ *   tags — consul_service_tags, or "nginx"
+ */
+typedef struct {
+    ngx_str_t    name;
+    ngx_str_t    addr;
+    ngx_uint_t   port;
+    ngx_str_t    tags;
+} ngx_http_consul_service_t;
+
+
+/*
+ * Main (http{}) configuration.
+ * Holds the global service catalogue snapshotted during postconfiguration.
+ */
+typedef struct {
+    ngx_array_t  *services;  /* array of ngx_http_consul_service_t entries  */
+    ngx_uint_t    updated;   /* incremented each time the catalogue is built */
+} ngx_http_consul_service_discovery_main_conf_t;
+
+
+/*
+ * Per-location{} configuration.
+ * Directive: consul_service_discovery on|off.
+ */
+typedef struct {
+    ngx_flag_t   enable;     /* consul_service_discovery on|off             */
+} ngx_http_consul_service_discovery_loc_conf_t;
+
+
+extern ngx_module_t  ngx_http_consul_service_discovery_module;
+
+#endif /* _NGX_HTTP_CONSUL_SERVICE_DISCOVERY_H_INCLUDED_ */

--- a/nginx/ngx_http_consul_service_discovery_module/src/ngx_http_consul_service_discovery_module.c
+++ b/nginx/ngx_http_consul_service_discovery_module/src/ngx_http_consul_service_discovery_module.c
@@ -1,0 +1,570 @@
+/*
+ * ngx_http_consul_service_discovery_module.c
+ *
+ * NGINX module that exposes server{} blocks tagged with
+ * consul_service_discoverable as a JSON service catalogue via a configurable
+ * location endpoint.  It does NOT talk to Consul directly; a sidecar (or
+ * Consul's own agent) can poll the endpoint and register/deregister services.
+ *
+ * Port and address auto-discovery
+ * ────────────────────────────────
+ * At postconfiguration time the module walks cmcf->ports, which is the array
+ * of ngx_http_conf_port_t entries built by the core module from every listen
+ * directive.  All postconfiguration hooks run before ngx_http_optimize_servers
+ * (ngx_http.c line 309 vs 335), so the temp-pool arrays are still live.
+ *
+ * For each discoverable server{} block ngx_http_consul_find_listen_info():
+ *
+ *   1. Scans cmcf->ports → addrs → servers[] by pointer equality against the
+ *      target ngx_http_core_srv_conf_t *.
+ *
+ *   2. Reads the matched ngx_http_conf_addr_t.opt.sockaddr with
+ *      ngx_sock_ntop(..., port=0) to get the bind IP ("0.0.0.0", "1.2.3.4",
+ *      "::", etc.) without the port suffix.  Buffer is allocated on cf->pool
+ *      (permanent pool) and thus valid for the worker lifetime.
+ *
+ *   3. Reads ngx_http_conf_port_t.port — stored in host byte order because
+ *      ngx_inet_get_port calls ntohs before storing it.
+ *
+ * consul_service_port_override overrides the discovered port for NAT /
+ * load-balancer deployments.  The address is always auto-discovered from the
+ * listen directive; there is no address override directive.
+ *
+ * Copyright (c) 2024 – present, Contributors
+ * Licensed under the MIT License.  See LICENSE for details.
+ */
+
+#include <ngx_config.h>
+#include <ngx_core.h>
+#include <ngx_http.h>
+#include "ngx_http_consul_service_discovery.h"
+
+
+/* ── forward declarations ─────────────────────────────────────────────────── */
+
+static ngx_int_t ngx_http_consul_service_discovery_postconfiguration(
+    ngx_conf_t *cf);
+static ngx_int_t ngx_http_consul_service_discovery_collect_servers(
+    ngx_conf_t *cf);
+
+/*
+ * Fills srv->addr and srv->port from the listen directive of target_cscf.
+ * Returns NGX_OK on success (even if port is 0 — a warning is logged).
+ * Returns NGX_ERROR only on allocation failure.
+ */
+static ngx_int_t ngx_http_consul_find_listen_info(ngx_conf_t *cf,
+    ngx_http_core_srv_conf_t *target_cscf,
+    ngx_http_consul_service_t *srv);
+
+static ngx_int_t ngx_http_consul_service_discovery_handler(
+    ngx_http_request_t *r);
+
+static void *ngx_http_consul_service_discovery_create_main_conf(
+    ngx_conf_t *cf);
+static void *ngx_http_consul_service_discovery_create_srv_conf(
+    ngx_conf_t *cf);
+static char *ngx_http_consul_service_discovery_merge_srv_conf(
+    ngx_conf_t *cf, void *parent, void *child);
+static void *ngx_http_consul_service_discovery_create_loc_conf(
+    ngx_conf_t *cf);
+static char *ngx_http_consul_service_discovery_merge_loc_conf(
+    ngx_conf_t *cf, void *parent, void *child);
+
+
+/* ── directive table ──────────────────────────────────────────────────────── */
+
+static ngx_command_t  ngx_http_consul_service_discovery_commands[] = {
+
+    /*
+     * consul_service_discovery on|off;
+     * Context: location
+     */
+    { ngx_string("consul_service_discovery"),
+      NGX_HTTP_LOC_CONF | NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_LOC_CONF_OFFSET,
+      offsetof(ngx_http_consul_service_discovery_loc_conf_t, enable),
+      NULL },
+
+    /*
+     * consul_service_discoverable on|off;
+     * Context: server
+     */
+    { ngx_string("consul_service_discoverable"),
+      NGX_HTTP_SRV_CONF | NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_consul_service_discovery_srv_conf_t, discoverable),
+      NULL },
+
+    /*
+     * consul_service_name "<name>";
+     * Context: server
+     * Defaults to the first server_name value when omitted.
+     */
+    { ngx_string("consul_service_name"),
+      NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_consul_service_discovery_srv_conf_t, service_name),
+      NULL },
+
+    /*
+     * consul_service_tags "<tag1,tag2,...>";
+     * Context: server
+     */
+    { ngx_string("consul_service_tags"),
+      NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+      ngx_conf_set_str_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_consul_service_discovery_srv_conf_t, tags),
+      NULL },
+
+    /*
+     * consul_service_port_override <port>;
+     * Context: server
+     * Optional.  Overrides the auto-discovered listen port.  Use only when
+     * the external port consumers connect to differs from the NGINX listen
+     * port (NAT / load-balancer).  The address is always auto-discovered.
+     */
+    { ngx_string("consul_service_port_override"),
+      NGX_HTTP_SRV_CONF | NGX_CONF_TAKE1,
+      ngx_conf_set_num_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_consul_service_discovery_srv_conf_t, port_override),
+      NULL },
+
+    ngx_null_command
+};
+
+
+/* ── module context ───────────────────────────────────────────────────────── */
+
+static ngx_http_module_t  ngx_http_consul_service_discovery_module_ctx = {
+    NULL,                                                   /* preconfiguration  */
+    ngx_http_consul_service_discovery_postconfiguration,   /* postconfiguration */
+
+    ngx_http_consul_service_discovery_create_main_conf,    /* create main conf  */
+    NULL,                                                   /* init main conf    */
+
+    ngx_http_consul_service_discovery_create_srv_conf,     /* create srv conf   */
+    ngx_http_consul_service_discovery_merge_srv_conf,      /* merge  srv conf   */
+
+    ngx_http_consul_service_discovery_create_loc_conf,     /* create loc conf   */
+    ngx_http_consul_service_discovery_merge_loc_conf       /* merge  loc conf   */
+};
+
+
+/* ── module definition ────────────────────────────────────────────────────── */
+
+ngx_module_t  ngx_http_consul_service_discovery_module = {
+    NGX_MODULE_V1,
+    &ngx_http_consul_service_discovery_module_ctx,
+    ngx_http_consul_service_discovery_commands,
+    NGX_HTTP_MODULE,
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+    NGX_MODULE_V1_PADDING
+};
+
+
+/* ── configuration lifecycle ──────────────────────────────────────────────── */
+
+static void *
+ngx_http_consul_service_discovery_create_main_conf(ngx_conf_t *cf)
+{
+    ngx_http_consul_service_discovery_main_conf_t  *mcf;
+
+    mcf = ngx_pcalloc(cf->pool,
+              sizeof(ngx_http_consul_service_discovery_main_conf_t));
+    if (mcf == NULL) {
+        return NULL;
+    }
+
+    mcf->services = NULL;
+    mcf->updated  = 0;
+
+    return mcf;
+}
+
+
+static void *
+ngx_http_consul_service_discovery_create_srv_conf(ngx_conf_t *cf)
+{
+    ngx_http_consul_service_discovery_srv_conf_t  *conf;
+
+    conf = ngx_pcalloc(cf->pool,
+               sizeof(ngx_http_consul_service_discovery_srv_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    conf->discoverable  = NGX_CONF_UNSET;
+    ngx_str_null(&conf->service_name);
+    ngx_str_null(&conf->tags);
+    conf->port_override = NGX_CONF_UNSET_UINT;
+
+    return conf;
+}
+
+
+static char *
+ngx_http_consul_service_discovery_merge_srv_conf(ngx_conf_t *cf,
+    void *parent, void *child)
+{
+    ngx_http_consul_service_discovery_srv_conf_t  *prev = parent;
+    ngx_http_consul_service_discovery_srv_conf_t  *conf = child;
+
+    ngx_conf_merge_value(conf->discoverable, prev->discoverable, 0);
+    ngx_conf_merge_str_value(conf->service_name, prev->service_name, "");
+    ngx_conf_merge_str_value(conf->tags, prev->tags, "");
+    ngx_conf_merge_uint_value(conf->port_override, prev->port_override, 0);
+
+    return NGX_CONF_OK;
+}
+
+
+static void *
+ngx_http_consul_service_discovery_create_loc_conf(ngx_conf_t *cf)
+{
+    ngx_http_consul_service_discovery_loc_conf_t  *conf;
+
+    conf = ngx_pcalloc(cf->pool,
+               sizeof(ngx_http_consul_service_discovery_loc_conf_t));
+    if (conf == NULL) {
+        return NULL;
+    }
+
+    conf->enable = NGX_CONF_UNSET;
+
+    return conf;
+}
+
+
+static char *
+ngx_http_consul_service_discovery_merge_loc_conf(ngx_conf_t *cf,
+    void *parent, void *child)
+{
+    ngx_http_consul_service_discovery_loc_conf_t  *prev = parent;
+    ngx_http_consul_service_discovery_loc_conf_t  *conf = child;
+
+    ngx_conf_merge_value(conf->enable, prev->enable, 0);
+
+    return NGX_CONF_OK;
+}
+
+
+/* ── listen-directive address and port discovery ──────────────────────────── */
+
+/*
+ * ngx_http_consul_find_listen_info()
+ *
+ * Walk cmcf->ports → addrs → servers[] to find the listen entry for
+ * target_cscf, then populate srv->addr and srv->port.
+ *
+ * ADDRESS
+ *   Taken from the matched ngx_http_conf_addr_t.opt.sockaddr using
+ *   ngx_sock_ntop(..., port=0), which gives the bare IP with no port suffix:
+ *
+ *     listen 80;           → "0.0.0.0"
+ *     listen 0.0.0.0:80;   → "0.0.0.0"
+ *     listen 1.2.3.4:80;   → "1.2.3.4"
+ *     listen [::]:80;      → "::"
+ *     listen [::1]:443;    → "::1"
+ *
+ *   A permanent-pool buffer (NGX_SOCKADDR_STRLEN bytes) is allocated for the
+ *   text so srv->addr.data remains valid for the worker lifetime.
+ *
+ * PORT
+ *   ngx_http_conf_port_t.port is in host byte order — ngx_inet_get_port calls
+ *   ntohs before storing it (ngx_http.c:ngx_http_add_listen).
+ *
+ * MULTIPLE LISTEN DIRECTIVES
+ *   When a server{} block has more than one listen directive the first match
+ *   found by the port-then-address scan is used.  Set consul_service_port_override
+ *   to select a specific port when this matters.
+ *
+ * RETURN VALUE
+ *   NGX_OK    — addr and port filled (port may be 0 if no listen found;
+ *               a [warn] is emitted in that case)
+ *   NGX_ERROR — ngx_pnalloc failed
+ */
+static ngx_int_t
+ngx_http_consul_find_listen_info(ngx_conf_t *cf,
+    ngx_http_core_srv_conf_t *target_cscf,
+    ngx_http_consul_service_t *srv)
+{
+    ngx_http_core_main_conf_t  *cmcf;
+    ngx_http_conf_port_t       *ports;
+    ngx_http_conf_addr_t       *addrs;
+    ngx_http_core_srv_conf_t  **srvp;
+    u_char                     *buf;
+    size_t                      len;
+    ngx_uint_t                  p, a, s;
+
+    cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
+
+    if (cmcf->ports == NULL) {
+        goto not_found;
+    }
+
+    ports = cmcf->ports->elts;
+
+    for (p = 0; p < cmcf->ports->nelts; p++) {
+
+        if (ports[p].addrs.elts == NULL) {
+            continue;
+        }
+
+        addrs = ports[p].addrs.elts;
+
+        for (a = 0; a < ports[p].addrs.nelts; a++) {
+
+            if (addrs[a].servers.elts == NULL) {
+                continue;
+            }
+
+            srvp = addrs[a].servers.elts;
+
+            for (s = 0; s < addrs[a].servers.nelts; s++) {
+
+                if (srvp[s] != target_cscf) {
+                    continue;
+                }
+
+                /*
+                 * Found the matching listen entry.
+                 *
+                 * PORT — already in host byte order.
+                 */
+                srv->port = (ngx_uint_t) ports[p].port;
+
+                /*
+                 * ADDRESS — call ngx_sock_ntop with port=0 to get the bare
+                 * IP address without the ":port" suffix that addr_text
+                 * contains (addr_text was built with port=1).
+                 *
+                 * Allocate on cf->pool (permanent pool) so the data pointer
+                 * outlives cf->temp_pool and remains valid at request time.
+                 */
+                buf = ngx_pnalloc(cf->pool, NGX_SOCKADDR_STRLEN);
+                if (buf == NULL) {
+                    return NGX_ERROR;
+                }
+
+                len = ngx_sock_ntop(addrs[a].opt.sockaddr,
+                                    addrs[a].opt.socklen,
+                                    buf, NGX_SOCKADDR_STRLEN,
+                                    0 /* port=0: IP only, no ":port" */);
+
+                srv->addr.data = buf;
+                srv->addr.len  = len;
+
+                return NGX_OK;
+            }
+        }
+    }
+
+not_found:
+
+    ngx_log_error(NGX_LOG_WARN, cf->log, 0,
+        "consul_service_discovery: no listen entry found for server \"%V\"; "
+        "set consul_service_port_override to suppress this warning",
+        &srv->name);
+
+    ngx_str_set(&srv->addr, "");
+    srv->port = 0;
+
+    return NGX_OK;
+}
+
+
+/* ── server collection ────────────────────────────────────────────────────── */
+
+static ngx_int_t
+ngx_http_consul_service_discovery_collect_servers(ngx_conf_t *cf)
+{
+    ngx_http_consul_service_discovery_main_conf_t  *mcf;
+    ngx_http_core_main_conf_t                      *cmcf;
+    ngx_http_core_srv_conf_t                      **cscfp;
+    ngx_http_consul_service_discovery_srv_conf_t   *scf;
+    ngx_http_consul_service_t                      *srv;
+    ngx_uint_t                                      i, n;
+
+    static const ngx_str_t default_tags = ngx_string("nginx");
+
+    mcf  = ngx_http_conf_get_module_main_conf(cf,
+               ngx_http_consul_service_discovery_module);
+    cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
+
+    if (mcf->services == NULL) {
+        mcf->services = ngx_array_create(cf->pool, 8,
+                            sizeof(ngx_http_consul_service_t));
+        if (mcf->services == NULL) {
+            return NGX_ERROR;
+        }
+    }
+
+    cscfp = cmcf->servers.elts;
+    n     = cmcf->servers.nelts;
+
+    for (i = 0; i < n; i++) {
+
+        scf = ngx_http_conf_get_module_srv_conf(cscfp[i],
+                  ngx_http_consul_service_discovery_module);
+
+        if (scf == NULL || !scf->discoverable) {
+            continue;
+        }
+
+        srv = ngx_array_push(mcf->services);
+        if (srv == NULL) {
+            return NGX_ERROR;
+        }
+        ngx_memzero(srv, sizeof(ngx_http_consul_service_t));
+
+        /*
+         * Service name: consul_service_name if set, else first server_name.
+         * cscf->server_name is populated by the core's merge_srv_conf, which
+         * runs at ngx_http.c line 270 — before our postconfiguration at
+         * line 309.
+         */
+        srv->name = (scf->service_name.len > 0)
+                    ? scf->service_name
+                    : cscfp[i]->server_name;
+
+        /*
+         * Address and port: auto-discovered from the listen directive.
+         * consul_service_port_override overrides the port only.
+         */
+        if (ngx_http_consul_find_listen_info(cf, cscfp[i], srv) != NGX_OK) {
+            return NGX_ERROR;
+        }
+
+        if (scf->port_override != NGX_CONF_UNSET_UINT
+            && scf->port_override != 0)
+        {
+            srv->port = scf->port_override;
+        }
+
+        /* Tags: consul_service_tags if set, else the default "nginx". */
+        srv->tags = (scf->tags.len > 0) ? scf->tags : default_tags;
+    }
+
+    mcf->updated++;
+    return NGX_OK;
+}
+
+
+/* ── postconfiguration ────────────────────────────────────────────────────── */
+
+static ngx_int_t
+ngx_http_consul_service_discovery_postconfiguration(ngx_conf_t *cf)
+{
+    ngx_http_core_main_conf_t  *cmcf;
+    ngx_http_handler_pt        *h;
+
+    cmcf = ngx_http_conf_get_module_main_conf(cf, ngx_http_core_module);
+
+    h = ngx_array_push(&cmcf->phases[NGX_HTTP_CONTENT_PHASE].handlers);
+    if (h == NULL) {
+        return NGX_ERROR;
+    }
+    *h = ngx_http_consul_service_discovery_handler;
+
+    return ngx_http_consul_service_discovery_collect_servers(cf);
+}
+
+
+/* ── request handler ──────────────────────────────────────────────────────── */
+
+/*
+ * Serve GET|HEAD as application/json.
+ *
+ * Example output:
+ *   {"services":[
+ *     {"name":"api1","address":"0.0.0.0","port":80,"tags":"v1,public"},
+ *     {"name":"api2","address":"1.2.3.4","port":443,"tags":"v2,https"}
+ *   ]}
+ */
+static ngx_int_t
+ngx_http_consul_service_discovery_handler(ngx_http_request_t *r)
+{
+    ngx_http_consul_service_discovery_loc_conf_t  *lcf;
+    ngx_http_consul_service_discovery_main_conf_t *mcf;
+    ngx_http_consul_service_t                     *services;
+    ngx_buf_t                                     *b;
+    ngx_chain_t                                    out;
+    ngx_uint_t                                     i, n;
+    size_t                                         buf_size;
+
+    lcf = ngx_http_get_module_loc_conf(r,
+              ngx_http_consul_service_discovery_module);
+
+    if (lcf == NULL || !lcf->enable) {
+        return NGX_DECLINED;
+    }
+
+    if (r->method != NGX_HTTP_GET && r->method != NGX_HTTP_HEAD) {
+        return NGX_HTTP_NOT_ALLOWED;
+    }
+
+    mcf      = ngx_http_get_module_main_conf(r,
+                   ngx_http_consul_service_discovery_module);
+    services = (mcf->services != NULL) ? mcf->services->elts : NULL;
+    n        = (mcf->services != NULL) ? mcf->services->nelts : 0;
+
+    /*
+     * Buffer: 32 bytes base + 80 bytes JSON scaffolding per entry +
+     * variable name/addr/tags lengths.
+     */
+    buf_size = 32;
+    for (i = 0; i < n; i++) {
+        buf_size += 80
+                    + services[i].name.len
+                    + services[i].addr.len
+                    + services[i].tags.len;
+    }
+
+    b = ngx_create_temp_buf(r->pool, buf_size);
+    if (b == NULL) {
+        return NGX_HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    b->last = ngx_cpymem(b->last,
+                  "{\"services\":[",
+                  sizeof("{\"services\":[") - 1);
+
+    for (i = 0; i < n; i++) {
+        if (i > 0) {
+            *b->last++ = ',';
+        }
+
+        b->last = ngx_snprintf(b->last, (size_t)(b->end - b->last),
+            "{\"name\":\"%V\",\"address\":\"%V\",\"port\":%ui,\"tags\":\"%V\"}",
+            &services[i].name,
+            &services[i].addr,
+            services[i].port,
+            &services[i].tags);
+    }
+
+    b->last = ngx_cpymem(b->last, "]}", sizeof("]}") - 1);
+
+    b->last_buf      = 1;
+    b->last_in_chain = 1;
+
+    r->headers_out.status            = NGX_HTTP_OK;
+    r->headers_out.content_type.len  = sizeof("application/json") - 1;
+    r->headers_out.content_type.data = (u_char *) "application/json";
+    r->headers_out.content_length_n  = b->last - b->pos;
+
+    ngx_http_send_header(r);
+
+    if (r->method == NGX_HTTP_HEAD) {
+        return NGX_OK;
+    }
+
+    out.buf  = b;
+    out.next = NULL;
+
+    return ngx_http_output_filter(r, &out);
+}

--- a/nginx/ngx_http_consul_service_discovery_module/t/nginx.conf
+++ b/nginx/ngx_http_consul_service_discovery_module/t/nginx.conf
@@ -1,0 +1,57 @@
+# t/nginx.conf — smoke test fixture
+#
+# Tests automatic port and address discovery:
+#   - api-a listens on 19877, server_name "api-a.local"  → no override needed
+#   - api-b listens on 19878, server_name "api-b.local"  → no override needed
+#
+# Expected JSON:
+#   {"services":[
+#     {"name":"api-a","address":"api-a.local","port":19877,"tags":"v1,smoke"},
+#     {"name":"api-b","address":"api-b.local","port":19878,"tags":"v2,smoke"}
+#   ]}
+
+error_log  /tmp/ngx-consul-test-error.log warn;
+pid        /tmp/ngx-consul-test.pid;
+
+events {
+    worker_connections 64;
+}
+
+http {
+    access_log off;
+
+    server {
+        listen 19876;
+        server_name discovery.local;
+
+        location /consul/services {
+            consul_service_discovery on;
+        }
+    }
+
+    server {
+        listen 19877;
+        server_name api-a.local;
+
+        consul_service_discoverable  on;
+        consul_service_name          "api-a";
+        consul_service_tags          "v1,smoke";
+
+        location / {
+            return 200 "ok\n";
+        }
+    }
+
+    server {
+        listen 19878;
+        server_name api-b.local;
+
+        consul_service_discoverable  on;
+        consul_service_name          "api-b";
+        consul_service_tags          "v2,smoke";
+
+        location / {
+            return 200 "ok\n";
+        }
+    }
+}

--- a/nginx/ngx_http_consul_service_discovery_module/t/smoke.sh
+++ b/nginx/ngx_http_consul_service_discovery_module/t/smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# t/smoke.sh — integration smoke test
+#
+# Verified:
+#   1. nginx -t config validation
+#   2. Discovery endpoint responds
+#   3. Both service names present
+#   4. Ports auto-discovered from listen (19877, 19878)
+#   5. Address auto-discovered from listen IP ("0.0.0.0" for wildcard)
+#   6. Content-Type: application/json
+#   7. {"services":[...]} top-level shape
+
+set -euo pipefail
+
+NGINX_BIN="${1:?Usage: smoke.sh <nginx-binary> <nginx-conf>}"
+NGINX_CONF="${2:?Usage: smoke.sh <nginx-binary> <nginx-conf>}"
+
+DISCOVERY_URL="http://127.0.0.1:19876/consul/services"
+PID_FILE="/tmp/ngx-consul-test.pid"
+LOG_FILE="/tmp/ngx-consul-test-error.log"
+MAX_WAIT=10
+
+stop_nginx() {
+    if [ -f "$PID_FILE" ]; then
+        kill "$(cat "$PID_FILE")" 2>/dev/null || true
+        rm -f "$PID_FILE"
+    fi
+}
+trap stop_nginx EXIT
+
+echo "→ Validating config..."
+"$NGINX_BIN" -t -c "$NGINX_CONF" -p /tmp/
+
+echo "→ Starting NGINX..."
+"$NGINX_BIN" -c "$NGINX_CONF" -p /tmp/
+
+echo "→ Waiting for $DISCOVERY_URL..."
+elapsed=0
+until curl -sf "$DISCOVERY_URL" > /dev/null 2>&1; do
+    sleep 1
+    elapsed=$((elapsed + 1))
+    if [ "$elapsed" -ge "$MAX_WAIT" ]; then
+        echo "✗ Timed out after ${MAX_WAIT}s"
+        cat "$LOG_FILE" 2>/dev/null || true
+        exit 1
+    fi
+done
+
+RESPONSE=$(curl -sf "$DISCOVERY_URL")
+HEADERS=$(curl -sI "$DISCOVERY_URL")
+echo "→ Response: $RESPONSE"
+
+# Service names
+for svc in "api-a" "api-b"; do
+    if echo "$RESPONSE" | grep -q "\"$svc\""; then
+        echo "✓ Service name '$svc' found"
+    else
+        echo "✗ Service name '$svc' NOT found"; exit 1
+    fi
+done
+
+# Ports from listen directive
+for port in "19877" "19878"; do
+    if echo "$RESPONSE" | grep -q "\"port\":${port}"; then
+        echo "✓ Port $port auto-discovered"
+    else
+        echo "✗ Port $port NOT found"; echo "  $RESPONSE"; exit 1
+    fi
+done
+
+# Address from listen directive (wildcard → "0.0.0.0")
+if echo "$RESPONSE" | grep -q '"address":"0.0.0.0"'; then
+    echo "✓ Address \"0.0.0.0\" auto-discovered from listen"
+else
+    echo "✗ Address \"0.0.0.0\" NOT found"; echo "  $RESPONSE"; exit 1
+fi
+
+# Content-Type
+if echo "$HEADERS" | grep -qi "content-type: application/json"; then
+    echo "✓ Content-Type: application/json"
+else
+    echo "✗ Wrong Content-Type"; echo "$HEADERS"; exit 1
+fi
+
+# JSON shape
+if echo "$RESPONSE" | grep -qE '^\{"services":\['; then
+    echo "✓ Top-level JSON shape correct"
+else
+    echo "✗ Unexpected JSON shape: $RESPONSE"; exit 1
+fi
+
+echo ""
+echo "✓ All smoke tests passed"


### PR DESCRIPTION
### Proposed changes

Added a native C module to provide Consul-compatible service discovery for NGINX servers.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [X] If applicable, I have checked that any relevant tests pass after adding my changes.
- [X] If this is a new demo, I have added the demo info to both the [`CODEOWNERS`](/.github/CODEOWNERS) and [`README.md`](/README.md).
- [X] I have updated any relevant documentation ([`README.md`](/README.md) and/or [`CHANGELOG.md`](/CHANGELOG.md)).
